### PR TITLE
CI/linting: fixes #59 linters aren't run in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Install package dependencies
         run: npm i
 
+      - name: Run Linter
+        run: npm run lint-full
+
       - name: Run FrontEnd tests
-        run: npm run testclient 
+        run: npm run testclient
 
       - name: Run Core API tests
         run: npm run testcoreapi

--- a/client/package.json
+++ b/client/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint \"*/**/*.{js,jsx,ts,tsx}\"",
-    "format": "prettier --write \"*/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "eslint",
+    "lint-full": "eslint \"*/**/*.{js,jsx,ts,tsx}\"",
+    "format": "prettier --write",
+    "format-full": "prettier --write \"*/**/*.{js,jsx,ts,tsx}\"",
     "preview": "vite preview",
     "test": "vitest run",
     "codegen": "graphql-codegen --config codegen.ts"

--- a/core_api/package.json
+++ b/core_api/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "test": "jest --config ./jest.config.ts",
     "dev": "ts-node-dev --respawn ./src/index.ts",
-    "lint": "eslint \"*/**/*.{js,jsx,ts,tsx}\"",
-    "format": "prettier --write \"*/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "eslint",
+    "lint-full": "eslint \"*/**/*.{js,jsx,ts,tsx}\"",
+    "format": "prettier --write",
+    "format-full": "prettier --write \"*/**/*.{js,jsx,ts,tsx}\"",
     "seed-dev": "ts-node-dev ./src/database/seed.dev.ts"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "testcoreapi": "npm run test --prefix core_api",
     "prepare": "husky",
     "lint": "lint-staged",
+    "lint-full": "npm run lint-full --prefix client && npm run lint-full --prefix core_api",
     "dev-restart": "make devdown && make prune && make rebuild && make dev",
     "install": "npm install --prefix client && npm install --prefix core_api"
   },


### PR DESCRIPTION
Fixes #59 

update test workflow to run lint (front and back) as first check job. update package.json files (root, client, coreapi) to use lint and format scripts without file glob paths when running via lint-staged, so that only staged files get checked on a local commit