### PR TITLE
Add tests to the layout component

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -41,12 +41,14 @@ export const Header = ({ page, pageNames }: HeaderProps) => {
       <section className="navbar-start">
         <img src={Logo} className="navbar-start w-16" />
       </section>
-      <title className="navbar-center text-2xl">{currentPageName}</title>
-      <nav className="navbar-end hidden md:flex">
+      <h1 role="title" className="navbar-center text-2xl">
+        {currentPageName}
+      </h1>
+      <nav role="navigation-desktop" className="navbar-end hidden md:flex">
         <ul className="menu menu-horizontal px-1">{navItems}</ul>
       </nav>
       <div className="navbar-end gap-2 md:hidden">
-        <nav className="dropdown dropdown-end">
+        <nav role="navigation-mobile" className="dropdown dropdown-end">
           <button
             tabIndex={0}
             role="button"

--- a/client/src/components/Layout/Layout.test.tsx
+++ b/client/src/components/Layout/Layout.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PageLayout } from './Layout';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('Test du composant Layout', () => {
+  it('Should display the Header component on /planning', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <PageLayout page="/planning">Hello</PageLayout>
+      </MemoryRouter>
+    );
+
+    const nav = screen.getByRole('navigation-desktop');
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('Should not display the Header component on /', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <PageLayout page="/">Hello</PageLayout>
+      </MemoryRouter>
+    );
+
+    const nav = screen.queryByRole('navigation-desktop');
+    expect(nav).toBeNull();
+  });
+
+  it('Should display the correct text in header', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <PageLayout page="/planning">Hello</PageLayout>
+      </MemoryRouter>
+    );
+
+    const title = screen.getByRole('title');
+    expect(title.textContent).toBe('Planning');
+  });
+});


### PR DESCRIPTION
In this PR i add basic tests to check if the component PageLayout displays well, we check that:

1) the Header component is displayed when logged in (we test on route '/planning' that the nav tag with role "navigation-desktop" is present in the page document)
2) on the login page '/' there is no Header (we test that the same nav tag with role "navigation-desktop" is absent from the page document)
3) the Header displays the correct title (for /planning: "Planning")

For this to work, i had to mock the router using the MemoryRouter from react-router, and also add roles on tags so i can find them with testing-library: i added a role for the title of the header and two for the nav (desktop and mobile)