### PR TITLE
FEATURE/test-password

### DIFF
--- a/core_api/package-lock.json
+++ b/core_api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.11.2",
+        "argon2": "^0.41.1",
         "class-validator": "^0.14.1",
         "dotenv": "^16.4.5",
         "graphql": "^16.9.0",
@@ -1741,6 +1742,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2643,6 +2653,30 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/argon2": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.41.1.tgz",
+      "integrity": "sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/argon2/node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6499,6 +6533,17 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/core_api/package.json
+++ b/core_api/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@apollo/server": "^4.11.2",
+    "argon2": "^0.41.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.5",
     "graphql": "^16.9.0",

--- a/core_api/src/database/seed.dev.ts
+++ b/core_api/src/database/seed.dev.ts
@@ -1,4 +1,8 @@
+import { hashPassword } from '../utils/auth.utils';
 import dataSource from './dataSource';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 (async () => {
   await dataSource.initialize();
@@ -92,12 +96,22 @@ import dataSource from './dataSource';
     const genderIdMap = await makeLabelIdMap('gender');
 
     // 2. USERS
-    // Fake email utilty
+    // Fake email utility
     // Add min one milisecond tick to avoid duplicate emails
     async function fakeEmail(): Promise<string> {
       const time = Date.now();
       await new Promise((resolve) => setTimeout(resolve, 3));
       return `fake${time}@fake.com`;
+    }
+
+    // Fake password utility
+    async function fakePassword(): Promise<string> {
+      const { TEST_USER_PASSWORD } = process.env;
+      if (!TEST_USER_PASSWORD) {
+        throw new Error('TEST_USER_PASSWORD environment variable not set');
+      }
+      const hashedPassword = await hashPassword(TEST_USER_PASSWORD);
+      return hashedPassword;
     }
 
     // DOCTORS
@@ -106,7 +120,7 @@ import dataSource from './dataSource';
         firstname: 'Cyril',
         lastname: 'Convergence',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.doctor,
         genderId: genderIdMap.male,
         departmentId: Math.floor(Math.random() * departments.length) + 1
@@ -115,7 +129,7 @@ import dataSource from './dataSource';
         firstname: 'Diana',
         lastname: 'Divergence',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.doctor,
         genderId: genderIdMap.female,
         departmentId: Math.floor(Math.random() * departments.length) + 1
@@ -144,7 +158,7 @@ import dataSource from './dataSource';
         firstname: 'Arnold',
         lastname: 'Agent',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.agent,
         genderId: genderIdMap.na
       },
@@ -152,7 +166,7 @@ import dataSource from './dataSource';
         firstname: 'Anna',
         lastname: 'Agent',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.agent,
         genderId: genderIdMap.na
       }
@@ -177,7 +191,7 @@ import dataSource from './dataSource';
         firstname: 'Alice',
         lastname: 'Admin',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.admin,
         genderId: genderIdMap.na
       },
@@ -185,7 +199,7 @@ import dataSource from './dataSource';
         firstname: 'Albert',
         lastname: 'Admin',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.admin,
         genderId: genderIdMap.na
       }
@@ -210,7 +224,7 @@ import dataSource from './dataSource';
         firstname: 'Samuel',
         lastname: 'Secretary',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.secretary,
         genderId: genderIdMap.na,
         departmentId: Math.floor(Math.random() * departments.length) + 1
@@ -219,7 +233,7 @@ import dataSource from './dataSource';
         firstname: 'Sally',
         lastname: 'Secretary',
         email: await fakeEmail(),
-        password: 'fake1234hash',
+        password: await fakePassword(),
         roleId: roleIdMap.secretary,
         genderId: genderIdMap.na,
         departmentId: Math.floor(Math.random() * departments.length) + 1

--- a/core_api/src/utils/auth.utils.ts
+++ b/core_api/src/utils/auth.utils.ts
@@ -1,0 +1,12 @@
+import * as argon2 from 'argon2';
+
+export async function hashPassword(password: string): Promise<string> {
+  return await argon2.hash(password);
+}
+
+export async function verifyPassword(
+  plainPassword: string,
+  hashedPassword: string
+): Promise<boolean> {
+  return await argon2.verify(hashedPassword, plainPassword);
+}


### PR DESCRIPTION
- Add Argon2 to coreapi
- Create auth utils with password hash / verify hash methods
- Update seed to create Argon2 hashed passwords for each fake seed user based on a pre-defined test password set in .env

(PR separate from the user login story, so that the seed can be kept up to date for everyone and the auth utils structure is in place in the back asap).

Completes #85 