### PR TITLE
Refacto/role map

### DIFF
--- a/client/src/components/OptionSelect/OptionSelect.tsx
+++ b/client/src/components/OptionSelect/OptionSelect.tsx
@@ -1,10 +1,10 @@
-import roleMap from '../UserList/roleMap';
+import { roleMap } from '../UserList/roleMap';
 
 export default function OptionSelect() {
   return (
     <>
       {Object.entries(roleMap).map(([key, value]) => (
-        <option key={key} value={key}>
+        <option key={key} value={key.toLowerCase()}>
           Role : {value}
         </option>
       ))}

--- a/client/src/components/UserList/UserList.tsx
+++ b/client/src/components/UserList/UserList.tsx
@@ -1,40 +1,46 @@
-import UserProps from './UserList.types';
-import roleMap from './roleMap';
+import { UsersQuery } from '../../generated/graphql-types';
+import translateRole from './roleMap';
 import EditIcon from '../../icons/EditIcon';
 import ArchiveIcon from '../../icons/ArchiveIcon';
 
 export default function UserList({
-  id,
-  name,
-  lastName,
-  email,
-  role
-}: UserProps) {
+  filteredUsers
+}: {
+  filteredUsers: UsersQuery['users'];
+}) {
   // function for translate role bdd to role french
-  const translatedRole = roleMap[role];
+  // const translatedRole = roleMap[filteredUsers[0].role.label];
 
   return (
-    <tr id={id.toString()} className="border-b border-gray-300">
-      <td>{translatedRole ? translatedRole : role}</td>
-      <td>{name}</td>
-      <td>{lastName}</td>
-      <td>{email}</td>
-      <td className="flex gap-2">
-        <button
-          type="button"
-          className="m-0 inline-flex items-center gap-2 rounded-lg bg-primary-light p-2 hover:bg-primary-dark hover:text-white"
+    <>
+      {filteredUsers.map((user) => (
+        <tr
+          key={user.id}
+          id={user.id.toString()}
+          className="border-b border-gray-300"
         >
-          <EditIcon />
-          Modifier
-        </button>
-        <button
-          type="button"
-          className="m-0 inline-flex items-center gap-2 rounded-lg bg-danger-lighter p-2 hover:bg-danger-dark hover:text-white"
-        >
-          <ArchiveIcon />
-          Archiver
-        </button>
-      </td>
-    </tr>
+          <td>{translateRole(user.role.label)}</td>
+          <td>{user.firstname}</td>
+          <td>{user.lastname}</td>
+          <td>{user.email}</td>
+          <td className="flex gap-2">
+            <button
+              type="button"
+              className="m-0 inline-flex items-center gap-2 rounded-lg bg-primary-light p-2 hover:bg-primary-dark hover:text-white"
+            >
+              <EditIcon />
+              Modifier
+            </button>
+            <button
+              type="button"
+              className="m-0 inline-flex items-center gap-2 rounded-lg bg-danger-lighter p-2 hover:bg-danger-dark hover:text-white"
+            >
+              <ArchiveIcon />
+              Archiver
+            </button>
+          </td>
+        </tr>
+      ))}
+    </>
   );
 }

--- a/client/src/components/UserList/roleMap.ts
+++ b/client/src/components/UserList/roleMap.ts
@@ -1,8 +1,12 @@
-const roleMap = {
-  agent: 'Agent',
-  secretary: 'Secrétaire',
-  doctor: 'Médecin',
-  admin: 'Admin'
+import { RoleLabel } from '../../generated/graphql-types';
+
+export const roleMap = {
+  AGENT: 'Agent',
+  SECRETARY: 'Secrétaire',
+  DOCTOR: 'Médecin',
+  ADMIN: 'Admin'
 };
 
-export default roleMap;
+export default function translateRole(label: RoleLabel): string {
+  return roleMap[label as keyof typeof roleMap];
+}

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -103,6 +103,7 @@ export type Query = {
   dossier: Array<Consultation>;
   patient: Patient;
   roles: Array<Role>;
+  users: Array<User>;
 };
 
 export type QueryDossierArgs = {
@@ -233,6 +234,20 @@ export type DepartmentsQueryVariables = Exact<{ [key: string]: never }>;
 export type DepartmentsQuery = {
   __typename?: 'Query';
   departments: Array<{ __typename?: 'Department'; id: number; label: string }>;
+};
+
+export type UsersQueryVariables = Exact<{ [key: string]: never }>;
+
+export type UsersQuery = {
+  __typename?: 'Query';
+  users: Array<{
+    __typename?: 'User';
+    id: number;
+    firstname: string;
+    lastname: string;
+    email: string;
+    role: { __typename?: 'Role'; id: number; label: string };
+  }>;
 };
 
 export const DossierDocument = gql`
@@ -626,4 +641,75 @@ export type DepartmentsSuspenseQueryHookResult = ReturnType<
 export type DepartmentsQueryResult = Apollo.QueryResult<
   DepartmentsQuery,
   DepartmentsQueryVariables
+>;
+export const UsersDocument = gql`
+  query Users {
+    users {
+      id
+      firstname
+      lastname
+      email
+      role {
+        id
+        label
+      }
+    }
+  }
+`;
+
+/**
+ * __useUsersQuery__
+ *
+ * To run a query within a React component, call `useUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useUsersQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useUsersQuery(
+  baseOptions?: Apollo.QueryHookOptions<UsersQuery, UsersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<UsersQuery, UsersQueryVariables>(
+    UsersDocument,
+    options
+  );
+}
+export function useUsersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<UsersQuery, UsersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<UsersQuery, UsersQueryVariables>(
+    UsersDocument,
+    options
+  );
+}
+export function useUsersSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<UsersQuery, UsersQueryVariables>
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<UsersQuery, UsersQueryVariables>(
+    UsersDocument,
+    options
+  );
+}
+export type UsersQueryHookResult = ReturnType<typeof useUsersQuery>;
+export type UsersLazyQueryHookResult = ReturnType<typeof useUsersLazyQuery>;
+export type UsersSuspenseQueryHookResult = ReturnType<
+  typeof useUsersSuspenseQuery
+>;
+export type UsersQueryResult = Apollo.QueryResult<
+  UsersQuery,
+  UsersQueryVariables
 >;

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -117,9 +117,17 @@ export type QueryPatientArgs = {
 export type Role = {
   __typename?: 'Role';
   id: Scalars['Int']['output'];
-  label: Scalars['String']['output'];
-  users?: Maybe<Array<User>>;
+  label: RoleLabel;
+  users: Array<User>;
 };
+
+/** The roles available to a user */
+export enum RoleLabel {
+  Admin = 'ADMIN',
+  Agent = 'AGENT',
+  Doctor = 'DOCTOR',
+  Secretary = 'SECRETARY'
+}
 
 export type User = {
   __typename?: 'User';
@@ -179,7 +187,7 @@ export type DossierQuery = {
         __typename?: 'User';
         firstname: string;
         lastname: string;
-        role: { __typename?: 'Role'; label: string };
+        role: { __typename?: 'Role'; label: RoleLabel };
       };
     }>;
   }>;
@@ -209,7 +217,7 @@ export type RolesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type RolesQuery = {
   __typename?: 'Query';
-  roles: Array<{ __typename?: 'Role'; id: number; label: string }>;
+  roles: Array<{ __typename?: 'Role'; id: number; label: RoleLabel }>;
 };
 
 export type RolesWithUsersQueryVariables = Exact<{ [key: string]: never }>;
@@ -219,13 +227,13 @@ export type RolesWithUsersQuery = {
   roles: Array<{
     __typename?: 'Role';
     id: number;
-    label: string;
-    users?: Array<{
+    label: RoleLabel;
+    users: Array<{
       __typename?: 'User';
       id: number;
       firstname: string;
       lastname: string;
-    }> | null;
+    }>;
   }>;
 };
 
@@ -246,7 +254,7 @@ export type UsersQuery = {
     firstname: string;
     lastname: string;
     email: string;
-    role: { __typename?: 'Role'; id: number; label: string };
+    role: { __typename?: 'Role'; id: number; label: RoleLabel };
   }>;
 };
 

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useUsersQuery } from '../../generated/graphql-types';
 import UserList from '../../components/UserList/UserList';
 import SearchBar from '../../components/SearchBar/SearchBar';
 import OptionSelect from '../../components/OptionSelect/OptionSelect';
-import users from './fakeUsers';
 
 export default function Admin() {
+  const { data, loading, error } = useUsersQuery();
+
   const [searchByName, setSearchByName] = useState<string>('');
   const [role, setRole] = useState<string>('');
 
@@ -12,79 +14,84 @@ export default function Admin() {
     setSearchByName(value);
   };
 
-  // function to filter by name, first name depending on the role
-  const filteredUsers = users.filter(
-    (user) =>
-      user.role.toLowerCase().includes(role.toLowerCase()) &&
-      (user.name.toLowerCase().includes(searchByName.toLowerCase()) ||
-        user.lastName.toLowerCase().includes(searchByName.toLowerCase()))
-  );
+  const filteredUsers =
+    data?.users?.filter(
+      (user) =>
+        user.role.label.toLowerCase().includes(role.toLowerCase()) &&
+        (user.firstname.toLowerCase().includes(searchByName.toLowerCase()) ||
+          user.lastname.toLowerCase().includes(searchByName.toLowerCase()))
+    ) || [];
+
+  if (loading) return <h1>Chargement ...</h1>;
+
+  if (error) return <h1>Erreur</h1>;
 
   // See https://daisyui.com/components/table/ for table component
-  return (
-    <>
-      <section className="h-5/6 min-h-3.5 pl-[15vw] pr-[15vw]">
-        <section className="flex p-[27px]">
-          <div className="basis-1/4">{''}</div>
-          <h2 className="basis-3/4 text-center font-bold">
-            Liste des utilisateurs
-          </h2>
-          <button
-            type="button"
-            className="basis-1/4 rounded-lg bg-primary-dark p-2 text-white hover:bg-secondary"
-          >
-            Ajouter un utilisateur
-          </button>
-        </section>
-        <div className="overflow-x-auto rounded-lg border border-primary-dark p-6">
-          <SearchBar handleChange={handleChange} />
-          <table className="table bg-white">
-            <thead>
-              <tr className="border-b border-gray-300">
-                <th scope="col">
-                  <label htmlFor="role">
-                    <select
-                      id="role"
-                      className="m-[-10px] rounded-lg border border-primary-dark p-2 focus:outline-none"
-                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                        setRole(e.target.value)
-                      }
-                    >
-                      <option value="">Roles : tous</option>
-                      <OptionSelect />
-                    </select>
-                  </label>
-                </th>
-                <th scope="col">Nom</th>
-                <th scope="col">Prénom</th>
-                <th scope="col">E-mail</th>
-                <th scope="col" className="w-28">
-                  Action
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredUsers.map((user) => (
-                <UserList
-                  key={user.id}
-                  id={user.id}
-                  name={user.name}
-                  lastName={user.lastName}
-                  email={user.email}
-                  role={user.role}
-                />
-              ))}
-            </tbody>
-          </table>
-          <section className="w-full text-right">
-            <div className="join">
-              <button className="btn join-item">«</button>
-              <button className="btn join-item">Page 01</button>
-              <button className="btn join-item">»</button>
-            </div>
+  if (data)
+    return (
+      <>
+        <section className="h-5/6 min-h-3.5 pl-[15vw] pr-[15vw]">
+          <section className="flex p-[27px]">
+            <div className="basis-1/4">{''}</div>
+            <h2 className="basis-3/4 text-center font-bold">
+              Liste des utilisateurs
+            </h2>
+            <button
+              type="button"
+              className="basis-1/4 rounded-lg bg-primary-dark p-2 text-white hover:bg-secondary"
+            >
+              Ajouter un utilisateur
+            </button>
           </section>
-        </div>
-      </section>
-    </>
-  );
+          <div className="overflow-x-auto rounded-lg border border-primary-dark p-6">
+            <SearchBar handleChange={handleChange} />
+            <table className="table bg-white">
+              <thead>
+                <tr className="border-b border-gray-300">
+                  <th scope="col">
+                    <label htmlFor="role">
+                      <select
+                        id="role"
+                        className="m-[-10px] rounded-lg border border-primary-dark p-2 focus:outline-none"
+                        onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                          setRole(e.target.value)
+                        }
+                      >
+                        <option value="">Roles : tous</option>
+                        <OptionSelect />
+                      </select>
+                    </label>
+                  </th>
+                  <th scope="col">Nom</th>
+                  <th scope="col">Prénom</th>
+                  <th scope="col">E-mail</th>
+                  <th scope="col" className="w-28">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredUsers.map((user) => (
+                  <UserList
+                    key={user.id}
+                    id={user.id}
+                    name={user.firstname}
+                    lastName={user.lastname}
+                    email={user.email}
+                    role={user.role.label}
+                  />
+                ))}
+              </tbody>
+            </table>
+            <section className="w-full text-right">
+              <div className="join">
+                <button className="btn join-item">«</button>
+                <button className="btn join-item">Page 01</button>
+                <button className="btn join-item">»</button>
+              </div>
+            </section>
+          </div>
+        </section>
+      </>
+    );
 }

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -6,7 +6,6 @@ import OptionSelect from '../../components/OptionSelect/OptionSelect';
 
 export default function Admin() {
   const { data, loading, error } = useUsersQuery();
-
   const [searchByName, setSearchByName] = useState<string>('');
   const [role, setRole] = useState<string>('');
 
@@ -23,7 +22,6 @@ export default function Admin() {
     ) || [];
 
   if (loading) return <h1>Chargement ...</h1>;
-
   if (error) return <h1>Erreur</h1>;
 
   // See https://daisyui.com/components/table/ for table component
@@ -71,16 +69,7 @@ export default function Admin() {
                 </tr>
               </thead>
               <tbody>
-                {filteredUsers.map((user) => (
-                  <UserList
-                    key={user.id}
-                    id={user.id}
-                    name={user.firstname}
-                    lastName={user.lastname}
-                    email={user.email}
-                    role={user.role.label}
-                  />
-                ))}
+                <UserList filteredUsers={filteredUsers} />
               </tbody>
             </table>
             <section className="w-full text-right">

--- a/client/src/schemas/userAdmin.schema.ts
+++ b/client/src/schemas/userAdmin.schema.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client';
+
+export const GET_USERS = gql`
+  query Users {
+    users {
+      id
+      firstname
+      lastname
+      email
+      role {
+        id
+        label
+      }
+    }
+  }
+`;

--- a/core_api/src/modules/role/role.entity.ts
+++ b/core_api/src/modules/role/role.entity.ts
@@ -3,23 +3,36 @@ import {
   Column,
   PrimaryGeneratedColumn,
   BaseEntity,
-  OneToMany
+  OneToMany,
+  Check
 } from 'typeorm';
-import { Field, ObjectType, Int } from 'type-graphql';
+import { Field, ObjectType, Int, registerEnumType } from 'type-graphql';
 import { User } from '../entities.index';
 
+export enum RoleLabel {
+  AGENT = 'agent',
+  SECRETARY = 'secretary',
+  DOCTOR = 'doctor',
+  ADMIN = 'admin'
+}
+
+registerEnumType(RoleLabel, {
+  name: 'RoleLabel',
+  description: 'The roles available to a user'
+});
 @ObjectType()
+@Check(`"label" IN ('agent', 'secretary', 'doctor', 'admin')`)
 @Entity()
 export class Role extends BaseEntity {
   @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Field(() => String)
+  @Field(() => RoleLabel)
   @Column({ nullable: false, unique: true, type: 'varchar', length: 30 })
-  label: string;
+  label: RoleLabel;
 
-  @Field(() => [User], { nullable: true })
+  @Field(() => [User], { nullable: false })
   @OneToMany(() => User, (user) => user.role)
   users: User[];
 }

--- a/core_api/src/modules/user/user.resolver.ts
+++ b/core_api/src/modules/user/user.resolver.ts
@@ -1,0 +1,12 @@
+import { User } from '../entities.index';
+import { Resolver, Query } from 'type-graphql';
+
+@Resolver(User)
+export default class userResolver {
+  @Query(() => [User])
+  async users() {
+    return await User.find({
+      relations: ['role', 'department', 'gender'] // Charge explicitement la relation "role"
+    });
+  }
+}

--- a/core_api/src/schema.ts
+++ b/core_api/src/schema.ts
@@ -3,6 +3,7 @@ import RoleResolver from './modules/role/role.resolver';
 import DepartmentResolver from './modules/department/department.resolver';
 import ConsultationResolver from './modules/consultation/consultation.resolver';
 import PatientResolver from './modules/patient/patient.resolver';
+import userResolver from './modules/user/user.resolver';
 
 const getSchema = async () => {
   return await buildSchema({
@@ -10,7 +11,8 @@ const getSchema = async () => {
       RoleResolver,
       ConsultationResolver,
       PatientResolver,
-      DepartmentResolver
+      DepartmentResolver,
+      userResolver
     ],
 
     validate: true


### PR DESCRIPTION
# Refactoring

## **Capture d'écran**
![Capture d'écran 2024-12-11 155808](https://github.com/user-attachments/assets/c40f772e-3c4a-41d8-84ec-0b36003cc8e8)

---

## **Changements apportés**

1. **Ajout d'un type Enum dans `role.entity`**
   - Objectif : Augmenter la maintenabilité en définissant un ensemble clair et strict des rôles possibles.
  
2. **Ajout de la query UserQuery**
   - Récupération des utilisateur de la base de donnée.

3. **Amélioration de la page Admin**
   - Utilisation d'un `map` dans le composant `UserList` pour simplifier et améliorer la logique de rendu.

4. **Ajout d'une fonction `translateRole()` dans `roleMap`**
   - Objectif : Centraliser la logique de traduction des rôles pour une utilisation plus cohérente dans tout le projet.

5. **Import du type `RoleLabel` depuis `graphql-types`**
   - Utilisé pour assurer la correspondance stricte des rôles définis côté GraphQL avec ceux utilisés dans le code TypeScript.

