### PR TITLE
Fix/labels

### DIFF
--- a/client/src/components/AdminPopup/AdminPopup.test.tsx
+++ b/client/src/components/AdminPopup/AdminPopup.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithAllProviders as render } from '../../utils/test/test.utils';
 import { vi } from 'vitest';
 import AdminPopup from './AdminPopup';
 import {

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/auth/useAuth';
 import { HeaderProps } from './Header.types';
 import Logo from '/images/logo-main-white.png';
+import { RoleLabel } from '../../generated/graphql-types';
 
 export const Header = ({ page, pageNames }: HeaderProps) => {
   const { user, setUser } = useAuth();
@@ -15,7 +16,8 @@ export const Header = ({ page, pageNames }: HeaderProps) => {
 
   const navItems = (
     <>
-      {(currentRole === 'doctor' || currentRole === 'secretary') && (
+      {(currentRole === RoleLabel.Doctor ||
+        currentRole === RoleLabel.Secretary) && (
         <li>
           <a
             onClick={() => navigate('/planning')}
@@ -25,7 +27,7 @@ export const Header = ({ page, pageNames }: HeaderProps) => {
           </a>
         </li>
       )}
-      {currentRole === 'doctor' && (
+      {currentRole === RoleLabel.Doctor && (
         <li>
           <a
             onClick={() => navigate('dossiers')}

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -3,9 +3,11 @@ import { useAuth } from '../../contexts/auth/useAuth';
 import { HeaderProps } from './Header.types';
 import Logo from '/images/logo-main-white.png';
 import { RoleLabel } from '../../generated/graphql-types';
+import { useDisplayText } from '../../contexts/displayText/useDisplayText';
 
 export const Header = ({ page, pageNames }: HeaderProps) => {
   const { user, setUser } = useAuth();
+  const { t } = useDisplayText();
   const currentRole = user?.role.label;
   const navigate = useNavigate();
   const currentPageName = pageNames[page];
@@ -48,7 +50,7 @@ export const Header = ({ page, pageNames }: HeaderProps) => {
       <section className="navbar-start">
         <img src={Logo} className="navbar-start w-16" />
         {currentRole && (
-          <span className="text-xs">Connecté en tant que {currentRole}</span>
+          <span className="text-xs">Connecté en tant que {t(currentRole)}</span>
         )}
       </section>
       <h1 role="title" className="navbar-center text-2xl text-white">

--- a/client/src/components/Layout/Layout.test.tsx
+++ b/client/src/components/Layout/Layout.test.tsx
@@ -10,6 +10,10 @@ vi.mock('../../contexts/auth/useAuth', () => ({
   })
 }));
 
+vi.mock('../../contexts/displayText/useDisplayText', () => ({
+  useDisplayText: () => ({ t: vi.fn() })
+}));
+
 describe('Test du composant Layout', () => {
   it('Should display the Header component on /planning', async () => {
     render(

--- a/client/src/contexts/displayText/DisplayTextContext.tsx
+++ b/client/src/contexts/displayText/DisplayTextContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useState, useEffect, PropsWithChildren } from 'react';
+import { useAuth } from '../auth/useAuth';
+import { useDisplayTextQuery } from '../../generated/graphql-types';
+
+type DisplayTextContextType = {
+  displayText: Record<string, string> | null;
+};
+
+const DisplayTextContext = createContext<DisplayTextContextType | undefined>(
+  undefined
+);
+
+export const DisplayTextProvider = ({ children }: PropsWithChildren) => {
+  const { user } = useAuth();
+  const [displayText, setDisplayText] = useState<Record<string, string> | null>(
+    null
+  );
+  const { data, loading, error } = useDisplayTextQuery({ skip: !user });
+
+  useEffect(() => {
+    if (data && data.displayText) {
+      const displayTextMap = data.displayText.reduce(
+        (acc: Record<string, string>, item) => {
+          acc[item.label] = item.textFR;
+          return acc;
+        },
+        {}
+      );
+      setDisplayText(displayTextMap);
+    }
+  }, [data]);
+
+  if (loading) return <p>Loading display text...</p>;
+  if (error) return <p>Error loading display text</p>;
+
+  return (
+    <DisplayTextContext.Provider value={{ displayText }}>
+      {children}
+    </DisplayTextContext.Provider>
+  );
+};
+
+export default DisplayTextContext;

--- a/client/src/contexts/displayText/useDisplayText.ts
+++ b/client/src/contexts/displayText/useDisplayText.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import DisplayTextContext from './DisplayTextContext';
+
+export const useDisplayText = () => {
+  const context = useContext(DisplayTextContext);
+  if (context === undefined) {
+    throw new Error('useDisplayText must be used within a DisplayTextProvider');
+  }
+
+  const t = (label: string): string => {
+    return context.displayText?.[label.toLowerCase()] || label;
+  };
+
+  return { ...context, t };
+};

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -81,6 +81,13 @@ export type Department = {
   users: Array<User>;
 };
 
+export type DisplayText = {
+  __typename?: 'DisplayText';
+  id: Scalars['Int']['output'];
+  label: Scalars['String']['output'];
+  textFR: Scalars['String']['output'];
+};
+
 export type Gender = {
   __typename?: 'Gender';
   id: Scalars['Int']['output'];
@@ -122,6 +129,7 @@ export type Patient = {
 export type Query = {
   __typename?: 'Query';
   departments: Array<Department>;
+  displayText: Array<DisplayText>;
   dossier: Array<Consultation>;
   genders: Array<Gender>;
   /** Fetches departments by label and their doctors */
@@ -160,7 +168,7 @@ export type Role = {
   __typename?: 'Role';
   id: Scalars['Int']['output'];
   label: RoleLabel;
-  users: Array<User>;
+  users?: Maybe<Array<User>>;
 };
 
 /** The roles available to a user */
@@ -227,6 +235,17 @@ export type DepartmentsAndDoctorsQuery = {
     firstname: string;
     id: number;
     lastname: string;
+  }>;
+};
+
+export type DisplayTextQueryVariables = Exact<{ [key: string]: never }>;
+
+export type DisplayTextQuery = {
+  __typename?: 'Query';
+  displayText: Array<{
+    __typename?: 'DisplayText';
+    label: string;
+    textFR: string;
   }>;
 };
 
@@ -324,12 +343,12 @@ export type RolesWithUsersQuery = {
     __typename?: 'Role';
     id: number;
     label: RoleLabel;
-    users: Array<{
+    users?: Array<{
       __typename?: 'User';
       id: number;
       firstname: string;
       lastname: string;
-    }>;
+    }> | null;
   }>;
 };
 
@@ -654,6 +673,82 @@ export type DepartmentsAndDoctorsSuspenseQueryHookResult = ReturnType<
 export type DepartmentsAndDoctorsQueryResult = Apollo.QueryResult<
   DepartmentsAndDoctorsQuery,
   DepartmentsAndDoctorsQueryVariables
+>;
+export const DisplayTextDocument = gql`
+  query DisplayText {
+    displayText {
+      label
+      textFR
+    }
+  }
+`;
+
+/**
+ * __useDisplayTextQuery__
+ *
+ * To run a query within a React component, call `useDisplayTextQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDisplayTextQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDisplayTextQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDisplayTextQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    DisplayTextQuery,
+    DisplayTextQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<DisplayTextQuery, DisplayTextQueryVariables>(
+    DisplayTextDocument,
+    options
+  );
+}
+export function useDisplayTextLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DisplayTextQuery,
+    DisplayTextQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<DisplayTextQuery, DisplayTextQueryVariables>(
+    DisplayTextDocument,
+    options
+  );
+}
+export function useDisplayTextSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DisplayTextQuery,
+        DisplayTextQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<DisplayTextQuery, DisplayTextQueryVariables>(
+    DisplayTextDocument,
+    options
+  );
+}
+export type DisplayTextQueryHookResult = ReturnType<typeof useDisplayTextQuery>;
+export type DisplayTextLazyQueryHookResult = ReturnType<
+  typeof useDisplayTextLazyQuery
+>;
+export type DisplayTextSuspenseQueryHookResult = ReturnType<
+  typeof useDisplayTextSuspenseQuery
+>;
+export type DisplayTextQueryResult = Apollo.QueryResult<
+  DisplayTextQuery,
+  DisplayTextQueryVariables
 >;
 export const DossierDocument = gql`
   query Dossier($patientId: Float!) {

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -89,6 +89,20 @@ export type Gender = {
   users: Array<User>;
 };
 
+export type Mutation = {
+  __typename?: 'Mutation';
+  addUser: User;
+};
+
+export type MutationAddUserArgs = {
+  departmentLabel?: InputMaybe<Scalars['String']['input']>;
+  email: Scalars['String']['input'];
+  firstname: Scalars['String']['input'];
+  genderLabel?: InputMaybe<Scalars['String']['input']>;
+  lastname: Scalars['String']['input'];
+  roleLabel: Scalars['String']['input'];
+};
+
 export type Patient = {
   __typename?: 'Patient';
   consultations: Array<Consultation>;
@@ -109,6 +123,7 @@ export type Query = {
   __typename?: 'Query';
   departments: Array<Department>;
   dossier: Array<Consultation>;
+  genders: Array<Gender>;
   /** Fetches departments by label and their doctors */
   getDoctorByDepartment: Array<Department>;
   /** Fetches all users with the role of doctor */
@@ -182,6 +197,17 @@ export type WorkingHours = {
   weekday: Scalars['Int']['output'];
 };
 
+export type DepartmentsAndGendersAndRolesQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type DepartmentsAndGendersAndRolesQuery = {
+  __typename?: 'Query';
+  genders: Array<{ __typename?: 'Gender'; id: number; label: string }>;
+  departments: Array<{ __typename?: 'Department'; id: number; label: string }>;
+  roles: Array<{ __typename?: 'Role'; id: number; label: RoleLabel }>;
+};
+
 export type DepartmentsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type DepartmentsQuery = {
@@ -240,6 +266,13 @@ export type DossierQuery = {
       };
     }>;
   }>;
+};
+
+export type GendersQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GendersQuery = {
+  __typename?: 'Query';
+  genders: Array<{ __typename?: 'Gender'; id: number; label: string }>;
 };
 
 export type PatientQueryVariables = Exact<{
@@ -335,6 +368,34 @@ export type LoginQuery = {
   };
 };
 
+export type AddUserMutationVariables = Exact<{
+  firstname: Scalars['String']['input'];
+  lastname: Scalars['String']['input'];
+  email: Scalars['String']['input'];
+  roleLabel: Scalars['String']['input'];
+  departmentLabel?: InputMaybe<Scalars['String']['input']>;
+  genderLabel?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+export type AddUserMutation = {
+  __typename?: 'Mutation';
+  addUser: {
+    __typename?: 'User';
+    id: number;
+    firstname: string;
+    lastname: string;
+    email: string;
+    createdAt?: string | null;
+    role: { __typename?: 'Role'; id: number; label: RoleLabel };
+    department?: {
+      __typename?: 'Department';
+      id: number;
+      label: string;
+    } | null;
+    gender?: { __typename?: 'Gender'; id: number; label: string } | null;
+  };
+};
+
 export type GetAllUsersQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetAllUsersQuery = {
@@ -349,6 +410,92 @@ export type GetAllUsersQuery = {
   }>;
 };
 
+export const DepartmentsAndGendersAndRolesDocument = gql`
+  query DepartmentsAndGendersAndRoles {
+    genders {
+      id
+      label
+    }
+    departments {
+      id
+      label
+    }
+    roles {
+      id
+      label
+    }
+  }
+`;
+
+/**
+ * __useDepartmentsAndGendersAndRolesQuery__
+ *
+ * To run a query within a React component, call `useDepartmentsAndGendersAndRolesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDepartmentsAndGendersAndRolesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDepartmentsAndGendersAndRolesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDepartmentsAndGendersAndRolesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    DepartmentsAndGendersAndRolesQuery,
+    DepartmentsAndGendersAndRolesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    DepartmentsAndGendersAndRolesQuery,
+    DepartmentsAndGendersAndRolesQueryVariables
+  >(DepartmentsAndGendersAndRolesDocument, options);
+}
+export function useDepartmentsAndGendersAndRolesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DepartmentsAndGendersAndRolesQuery,
+    DepartmentsAndGendersAndRolesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    DepartmentsAndGendersAndRolesQuery,
+    DepartmentsAndGendersAndRolesQueryVariables
+  >(DepartmentsAndGendersAndRolesDocument, options);
+}
+export function useDepartmentsAndGendersAndRolesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        DepartmentsAndGendersAndRolesQuery,
+        DepartmentsAndGendersAndRolesQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    DepartmentsAndGendersAndRolesQuery,
+    DepartmentsAndGendersAndRolesQueryVariables
+  >(DepartmentsAndGendersAndRolesDocument, options);
+}
+export type DepartmentsAndGendersAndRolesQueryHookResult = ReturnType<
+  typeof useDepartmentsAndGendersAndRolesQuery
+>;
+export type DepartmentsAndGendersAndRolesLazyQueryHookResult = ReturnType<
+  typeof useDepartmentsAndGendersAndRolesLazyQuery
+>;
+export type DepartmentsAndGendersAndRolesSuspenseQueryHookResult = ReturnType<
+  typeof useDepartmentsAndGendersAndRolesSuspenseQuery
+>;
+export type DepartmentsAndGendersAndRolesQueryResult = Apollo.QueryResult<
+  DepartmentsAndGendersAndRolesQuery,
+  DepartmentsAndGendersAndRolesQueryVariables
+>;
 export const DepartmentsDocument = gql`
   query Departments {
     departments {
@@ -599,6 +746,71 @@ export type DossierSuspenseQueryHookResult = ReturnType<
 export type DossierQueryResult = Apollo.QueryResult<
   DossierQuery,
   DossierQueryVariables
+>;
+export const GendersDocument = gql`
+  query Genders {
+    genders {
+      id
+      label
+    }
+  }
+`;
+
+/**
+ * __useGendersQuery__
+ *
+ * To run a query within a React component, call `useGendersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGendersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGendersQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGendersQuery(
+  baseOptions?: Apollo.QueryHookOptions<GendersQuery, GendersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GendersQuery, GendersQueryVariables>(
+    GendersDocument,
+    options
+  );
+}
+export function useGendersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GendersQuery, GendersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GendersQuery, GendersQueryVariables>(
+    GendersDocument,
+    options
+  );
+}
+export function useGendersSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<GendersQuery, GendersQueryVariables>
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GendersQuery, GendersQueryVariables>(
+    GendersDocument,
+    options
+  );
+}
+export type GendersQueryHookResult = ReturnType<typeof useGendersQuery>;
+export type GendersLazyQueryHookResult = ReturnType<typeof useGendersLazyQuery>;
+export type GendersSuspenseQueryHookResult = ReturnType<
+  typeof useGendersSuspenseQuery
+>;
+export type GendersQueryResult = Apollo.QueryResult<
+  GendersQuery,
+  GendersQueryVariables
 >;
 export const PatientDocument = gql`
   query Patient($patientId: Float!) {
@@ -1068,6 +1280,88 @@ export type LoginSuspenseQueryHookResult = ReturnType<
 export type LoginQueryResult = Apollo.QueryResult<
   LoginQuery,
   LoginQueryVariables
+>;
+export const AddUserDocument = gql`
+  mutation AddUser(
+    $firstname: String!
+    $lastname: String!
+    $email: String!
+    $roleLabel: String!
+    $departmentLabel: String
+    $genderLabel: String
+  ) {
+    addUser(
+      firstname: $firstname
+      lastname: $lastname
+      email: $email
+      roleLabel: $roleLabel
+      departmentLabel: $departmentLabel
+      genderLabel: $genderLabel
+    ) {
+      id
+      firstname
+      lastname
+      email
+      role {
+        id
+        label
+      }
+      department {
+        id
+        label
+      }
+      gender {
+        id
+        label
+      }
+      createdAt
+    }
+  }
+`;
+export type AddUserMutationFn = Apollo.MutationFunction<
+  AddUserMutation,
+  AddUserMutationVariables
+>;
+
+/**
+ * __useAddUserMutation__
+ *
+ * To run a mutation, you first call `useAddUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addUserMutation, { data, loading, error }] = useAddUserMutation({
+ *   variables: {
+ *      firstname: // value for 'firstname'
+ *      lastname: // value for 'lastname'
+ *      email: // value for 'email'
+ *      roleLabel: // value for 'roleLabel'
+ *      departmentLabel: // value for 'departmentLabel'
+ *      genderLabel: // value for 'genderLabel'
+ *   },
+ * });
+ */
+export function useAddUserMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    AddUserMutation,
+    AddUserMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<AddUserMutation, AddUserMutationVariables>(
+    AddUserDocument,
+    options
+  );
+}
+export type AddUserMutationHookResult = ReturnType<typeof useAddUserMutation>;
+export type AddUserMutationResult = Apollo.MutationResult<AddUserMutation>;
+export type AddUserMutationOptions = Apollo.BaseMutationOptions<
+  AddUserMutation,
+  AddUserMutationVariables
 >;
 export const GetAllUsersDocument = gql`
   query GetAllUsers {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import { AuthProvider } from './contexts/auth/AuthContext.tsx';
+import { DisplayTextProvider } from './contexts/displayText/DisplayTextContext.tsx';
 import RedirectWrapper from './components/RedirectWrapper/RedirectWrapper.tsx';
 import { client } from './services/client';
 import App from './App.tsx';
@@ -67,7 +68,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ApolloProvider client={client}>
       <AuthProvider>
-        <RouterProvider router={router} />
+        <DisplayTextProvider>
+          <RouterProvider router={router} />
+        </DisplayTextProvider>
       </AuthProvider>
     </ApolloProvider>
   </StrictMode>

--- a/client/src/pages/Login/LoginDevButtons.tsx
+++ b/client/src/pages/Login/LoginDevButtons.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '../../contexts/auth/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { roleLandingPages } from './roleLandingPages';
+import { RoleLabel } from '../../generated/graphql-types';
 
 // This component is used to simulate login for different users roles.
 // It is used in the Login page for development purposes.
@@ -10,7 +11,7 @@ export default function LoginDevButtons() {
   const navigate = useNavigate();
   const { setUser } = useAuth();
 
-  const handleLogin = (role: 'agent' | 'secretary' | 'doctor' | 'admin') => {
+  const handleLogin = (role: RoleLabel) => {
     setUser({
       id: 1,
       firstname: 'John',
@@ -18,35 +19,39 @@ export default function LoginDevButtons() {
       email: 'test@test.com',
       role: {
         id: 1,
-        label: role
+        label: role,
+        users: []
       },
       isArchived: false
     });
-    navigate(roleLandingPages[role]);
+
+    setTimeout(() => {
+      navigate(roleLandingPages[role]);
+    }, 100); // Petit délai pour laisser le contexte se mettre à jour
   };
 
   return (
     <>
       <button
-        onClick={() => handleLogin('agent')}
+        onClick={() => handleLogin(RoleLabel.Agent)}
         className="btn w-40 bg-primary"
       >
         Login Agent
       </button>
       <button
-        onClick={() => handleLogin('secretary')}
+        onClick={() => handleLogin(RoleLabel.Secretary)}
         className="btn w-40 bg-primary"
       >
         Login Secretary
       </button>
       <button
-        onClick={() => handleLogin('doctor')}
+        onClick={() => handleLogin(RoleLabel.Doctor)}
         className="btn w-40 bg-primary"
       >
         Login Doctor
       </button>
       <button
-        onClick={() => handleLogin('admin')}
+        onClick={() => handleLogin(RoleLabel.Admin)}
         className="btn w-40 bg-primary"
       >
         Login Admin

--- a/client/src/pages/Login/LoginDevButtons.tsx
+++ b/client/src/pages/Login/LoginDevButtons.tsx
@@ -14,15 +14,12 @@ export default function LoginDevButtons() {
   const handleLogin = (role: RoleLabel) => {
     setUser({
       id: 1,
-      firstname: 'John',
-      lastname: 'Doe',
       email: 'test@test.com',
       role: {
         id: 1,
-        label: role,
-        users: []
+        label: role
       },
-      isArchived: false
+      token: 'test-token'
     });
 
     setTimeout(() => {

--- a/client/src/pages/Login/roleLandingPages.ts
+++ b/client/src/pages/Login/roleLandingPages.ts
@@ -1,6 +1,8 @@
-export const roleLandingPages = {
-  agent: '/rechercher',
-  secretary: '/planning',
-  doctor: '/planning',
-  admin: '/admin'
+import { RoleLabel } from '../../generated/graphql-types';
+
+export const roleLandingPages: Record<RoleLabel, string> = {
+  AGENT: '/rechercher',
+  SECRETARY: '/planning',
+  DOCTOR: '/planning',
+  ADMIN: '/admin'
 };

--- a/client/src/schemas/displayText.schema.ts
+++ b/client/src/schemas/displayText.schema.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const GET_DISPLAY_TEXT = gql`
+  query DisplayText {
+    displayText {
+      label
+      textFR
+    }
+  }
+`;

--- a/client/src/utils/test/test.utils.tsx
+++ b/client/src/utils/test/test.utils.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { DisplayTextProvider } from '../../contexts/displayText/DisplayTextContext';
+import { AuthProvider } from '../../contexts/auth/AuthContext';
+import { MockedProvider } from '@apollo/client/testing';
+
+// This is a custom render function that wraps the component to be tested in all required providers.
+// This allows tests that just need providers to be in the tree to be written more easily.
+// https://testing-library.com/docs/react-testing-library/setup#custom-render
+const AllProviders = ({ children }: { children: ReactNode }) => {
+  return (
+    <MockedProvider mocks={[]} addTypename={false}>
+      <AuthProvider>
+        <DisplayTextProvider>{children}</DisplayTextProvider>
+      </AuthProvider>
+    </MockedProvider>
+  );
+};
+
+export const renderWithAllProviders = (
+  ui: React.ReactElement,
+  options?: RenderOptions
+) => render(ui, { wrapper: AllProviders, ...options });

--- a/core_api/src/database/dataSource.ts
+++ b/core_api/src/database/dataSource.ts
@@ -9,7 +9,8 @@ import {
   Patient,
   Role,
   User,
-  WorkingHours
+  WorkingHours,
+  DisplayText
 } from '../modules/entities.index';
 
 dotenv.config();
@@ -25,7 +26,8 @@ const entities = [
   Consultation,
   ConsultationSubject,
   Attachment,
-  Patient
+  Patient,
+  DisplayText
 ];
 
 if (NODE_ENV === 'test') {

--- a/core_api/src/database/displaytext.json
+++ b/core_api/src/database/displaytext.json
@@ -1,0 +1,33 @@
+[
+  { "label": "admin", "textFR": "Administrateur" },
+  { "label": "doctor", "textFR": "Docteur" },
+  { "label": "agent", "textFR": "Agent" },
+  { "label": "secretary", "textFR": "Sécretaire" },
+  { "label": "male", "textFR": "Homme" },
+  { "label": "female", "textFR": "Femme" },
+  { "label": "na", "textFR": "Non applicable" },
+  { "label": "cardiology", "textFR": "Cardiologie" },
+  { "label": "dermatology", "textFR": "Dermatologie" },
+  { "label": "endocrinology", "textFR": "Endocrinologie" },
+  { "label": "gastroenterology", "textFR": "Gastroentérologie" },
+  { "label": "hematology", "textFR": "Hématologie" },
+  { "label": "infectious_diseases", "textFR": "Maladies infectieuses" },
+  { "label": "nephrology", "textFR": "Néphrologie" },
+  { "label": "neurology", "textFR": "Neurologie" },
+  { "label": "oncology", "textFR": "Oncologie" },
+  { "label": "pulmonology", "textFR": "Pneumologie" },
+  { "label": "rheumatology", "textFR": "Rhumatologie" },
+  { "label": "urology", "textFR": "Urologie" },
+  { "label": "general_consultation", "textFR": "Consultation générale" },
+  { "label": "followup_consultation", "textFR": "Consultation de suivi" },
+  { "label": "emergency_consultation", "textFR": "Consultation d'urgence" },
+  {
+    "label": "preoperative_consultation",
+    "textFR": "Consultation préopératoire"
+  },
+  {
+    "label": "postoperative_consultation",
+    "textFR": "Consultation postopératoire"
+  },
+  { "label": "routine_checkup", "textFR": "Bilan de routine" }
+]

--- a/core_api/src/database/seed.dev.ts
+++ b/core_api/src/database/seed.dev.ts
@@ -119,7 +119,7 @@ dotenv.config();
       {
         firstname: 'Cyril',
         lastname: 'Convergence',
-        email: await fakeEmail(),
+        email: 'fakedoctor@fake.com',
         password: await fakePassword(),
         roleId: roleIdMap.doctor,
         genderId: genderIdMap.male,
@@ -157,7 +157,7 @@ dotenv.config();
       {
         firstname: 'Arnold',
         lastname: 'Agent',
-        email: await fakeEmail(),
+        email: 'fakeagent@fake.com',
         password: await fakePassword(),
         roleId: roleIdMap.agent,
         genderId: genderIdMap.na
@@ -190,7 +190,7 @@ dotenv.config();
       {
         firstname: 'Alice',
         lastname: 'Admin',
-        email: await fakeEmail(),
+        email: 'fakeadmin@fake.com',
         password: await fakePassword(),
         roleId: roleIdMap.admin,
         genderId: genderIdMap.na
@@ -223,7 +223,7 @@ dotenv.config();
       {
         firstname: 'Samuel',
         lastname: 'Secretary',
-        email: await fakeEmail(),
+        email: 'fakesecretary@fake.com',
         password: await fakePassword(),
         roleId: roleIdMap.secretary,
         genderId: genderIdMap.na,
@@ -411,7 +411,19 @@ dotenv.config();
         consultation2.consultationDate = '2024-11-22';
         const consultation3 = { ...baseConsultation };
         consultation3.consultationDate = '2024-11-13';
-        return [consultation1, consultation2, consultation3];
+        // Create a consultation for today, in the next 2 hours
+        const consultation4 = { ...baseConsultation };
+        consultation4.consultationDate = new Date().toISOString().split('T')[0];
+        const now = new Date();
+        const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+        const randomTime = new Date(
+          now.getTime() +
+            Math.random() * (twoHoursLater.getTime() - now.getTime())
+        );
+        randomTime.setMinutes(Math.round(randomTime.getMinutes() / 15) * 15);
+        randomTime.setHours(randomTime.getHours() + 1); // Add one hour to offset from UTC
+        consultation4.startTime = randomTime.toTimeString().slice(0, 5);
+        return [consultation1, consultation2, consultation3, consultation4];
       }
     );
 

--- a/core_api/src/database/seed.dev.ts
+++ b/core_api/src/database/seed.dev.ts
@@ -1,6 +1,7 @@
 import { hashPassword } from '../utils/auth.utils';
 import dataSource from './dataSource';
 import * as dotenv from 'dotenv';
+import displayTextData from './displaytext.json';
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ dotenv.config();
     await queryRunner.query('TRUNCATE consultation RESTART IDENTITY CASCADE');
     await queryRunner.query('TRUNCATE patient RESTART IDENTITY CASCADE');
     await queryRunner.query('TRUNCATE "user" RESTART IDENTITY CASCADE');
+    await queryRunner.query('TRUNCATE display_text RESTART IDENTITY CASCADE');
 
     // SEED TABLES
     // 1. UNIQUE LABELS
@@ -35,25 +37,25 @@ dotenv.config();
     );
 
     // Genders
-    const genders = ['Male', 'Female', 'NA'];
+    const genders = ['male', 'female', 'na'];
     await queryRunner.query(
       `INSERT INTO "gender" (label) VALUES ('${genders.join("'), ('")}')`
     );
 
     // Departments
     const departments = [
-      'Cardiology',
-      'Dermatology',
-      'Endocrinology',
-      'Gastroenterology',
-      'Hematology',
-      'Infectious diseases',
-      'Nephrology',
-      'Neurology',
-      'Oncology',
-      'Pulmonology',
-      'Rheumatology',
-      'Urology'
+      'cardiology',
+      'dermatology',
+      'endocrinology',
+      'gastroenterology',
+      'hematology',
+      'infectious_diseases',
+      'nephrology',
+      'neurology',
+      'oncology',
+      'pulmonology',
+      'rheumatology',
+      'urology'
     ];
     await queryRunner.query(
       `INSERT INTO "department" (label) VALUES ('${departments.join("'), ('")}')`
@@ -61,12 +63,12 @@ dotenv.config();
 
     // Consultation subjects
     const consultationSubjects = [
-      'General consultation',
-      'Follow-up consultation',
-      'Emergency consultation',
-      'Preoperative consultation',
-      'Postoperative consultation',
-      'Routine check-up'
+      'general_consultation',
+      'followup_consultation',
+      'emergency_consultation',
+      'preoperative_consultation',
+      'postoperative_consultation',
+      'routine_checkup'
     ];
     await queryRunner.query(
       `INSERT INTO "consultation_subject" (label) VALUES ('${consultationSubjects.join("'), ('")}')`
@@ -94,6 +96,17 @@ dotenv.config();
 
     const roleIdMap = await makeLabelIdMap('role');
     const genderIdMap = await makeLabelIdMap('gender');
+
+    // Seed display text
+    const displayTextValues = displayTextData
+      .map((item) => `('${item.label}', '${item.textFR.replace(/'/g, "''")}')`)
+      .join(', ');
+
+    await queryRunner.query(`
+      INSERT INTO "display_text"
+      (label, "textFR")
+      VALUES ${displayTextValues}
+    `);
 
     // 2. USERS
     // Fake email utility

--- a/core_api/src/database/seed.jest.ts
+++ b/core_api/src/database/seed.jest.ts
@@ -110,7 +110,7 @@ const seed = async () => {
       {
         firstname: 'Cyril',
         lastname: 'Convergence',
-        email: await fakeEmail(),
+        email: 'fakedoctor@fake.com',
         password: 'fake1234hash',
         roleId: roleIdMap.doctor,
         genderId: genderIdMap.male,
@@ -148,7 +148,7 @@ const seed = async () => {
       {
         firstname: 'Arnold',
         lastname: 'Agent',
-        email: await fakeEmail(),
+        email: 'fakeagent@fake.com',
         password: 'fake1234hash',
         roleId: roleIdMap.agent,
         genderId: genderIdMap.na
@@ -181,7 +181,7 @@ const seed = async () => {
       {
         firstname: 'Alice',
         lastname: 'Admin',
-        email: await fakeEmail(),
+        email: 'fakeadmin@fake.com',
         password: 'fake1234hash',
         roleId: roleIdMap.admin,
         genderId: genderIdMap.na
@@ -214,7 +214,7 @@ const seed = async () => {
       {
         firstname: 'Samuel',
         lastname: 'Secretary',
-        email: await fakeEmail(),
+        email: 'fakesecretary@fake.com',
         password: 'fake1234hash',
         roleId: roleIdMap.secretary,
         genderId: genderIdMap.na,
@@ -402,7 +402,19 @@ const seed = async () => {
         consultation2.consultationDate = '2024-11-22';
         const consultation3 = { ...baseConsultation };
         consultation3.consultationDate = '2024-11-13';
-        return [consultation1, consultation2, consultation3];
+        // Create a consultation for today, in the next 2 hours
+        const consultation4 = { ...baseConsultation };
+        consultation4.consultationDate = new Date().toISOString().split('T')[0];
+        const now = new Date();
+        const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+        const randomTime = new Date(
+          now.getTime() +
+            Math.random() * (twoHoursLater.getTime() - now.getTime())
+        );
+        randomTime.setMinutes(Math.round(randomTime.getMinutes() / 15) * 15);
+        randomTime.setHours(randomTime.getHours() + 1); // Add one hour to offset from UTC
+        consultation4.startTime = randomTime.toTimeString().slice(0, 5);
+        return [consultation1, consultation2, consultation3, consultation4];
       }
     );
 

--- a/core_api/src/modules/display_text/displayText.entity.ts
+++ b/core_api/src/modules/display_text/displayText.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from 'typeorm';
+import { Field, ObjectType, Int } from 'type-graphql';
+
+@ObjectType()
+@Entity()
+export class DisplayText extends BaseEntity {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field(() => String)
+  @Column({ nullable: false, unique: true, type: 'varchar', length: 60 })
+  label: string;
+
+  @Field(() => String)
+  @Column({ nullable: false, type: 'varchar', length: 140 })
+  textFR: string;
+}

--- a/core_api/src/modules/display_text/displayText.resolver.ts
+++ b/core_api/src/modules/display_text/displayText.resolver.ts
@@ -1,0 +1,10 @@
+import { DisplayText } from './displayText.entity';
+import { Resolver, Query } from 'type-graphql';
+
+@Resolver(DisplayText)
+export default class DisplayTextResolver {
+  @Query(() => [DisplayText])
+  async displayText() {
+    return await DisplayText.find();
+  }
+}

--- a/core_api/src/modules/entities.index.ts
+++ b/core_api/src/modules/entities.index.ts
@@ -7,3 +7,4 @@ export * from './patient/patient.entity';
 export * from './role/role.entity';
 export * from './user/user.entity';
 export * from './working_hours/workingHours.entity';
+export * from './display_text/displayText.entity';

--- a/core_api/src/modules/role/role.entity.ts
+++ b/core_api/src/modules/role/role.entity.ts
@@ -32,7 +32,7 @@ export class Role extends BaseEntity {
   @Column({ nullable: false, unique: true, type: 'varchar', length: 30 })
   label: RoleLabel;
 
-  @Field(() => [User], { nullable: false })
+  @Field(() => [User], { nullable: true })
   @OneToMany(() => User, (user) => user.role)
   users: User[];
 }

--- a/core_api/src/schema.ts
+++ b/core_api/src/schema.ts
@@ -5,6 +5,7 @@ import ConsultationResolver from './modules/consultation/consultation.resolver';
 import PatientResolver from './modules/patient/patient.resolver';
 import UserResolver from './modules/user/user.resolver';
 import GenderResolver from './modules/gender/gender.resolver';
+import DisplayTextResolver from './modules/display_text/displayText.resolver';
 
 const getSchema = async () => {
   return await buildSchema({
@@ -14,7 +15,8 @@ const getSchema = async () => {
       PatientResolver,
       DepartmentResolver,
       UserResolver,
-      GenderResolver
+      GenderResolver,
+      DisplayTextResolver
     ],
 
     validate: true

--- a/core_api/tsconfig.json
+++ b/core_api/tsconfig.json
@@ -11,11 +11,11 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2017",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    "experimentalDecorators": true /* Enable experimental support for legacy experimental decorators. */,
+    "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
     // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
     // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -40,7 +40,7 @@
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true /* Enable importing .json files. */,
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
@@ -77,17 +77,17 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    "strictPropertyInitialization": false,             /* Check for class properties that are declared but not set in the constructor. */
+    "strictPropertyInitialization": false /* Check for class properties that are declared but not set in the constructor. */,
     // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
@@ -105,6 +105,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
- ( Incorporates the login RoleLabel related changes by @Adri-bis in #102 )

- Adds a display_text table to the bdd with static values mapping labels to French display text
- Adds a DisplayTextContext to the client which loads these values when the user first connects
- Adds a useDisplayText hook which provide a utility method t(label), to be used anywhere preset UI label: displayText mappings are needed

This PR was proposed as a solution to various problems working with EN strings in logic without a clearly defined structure for translation / mapping between these and the FR displayText required for UI.

This approach has the possible advantage of solving these problems for all entities that use labels in one step, without modifying existing bdd tables and without requiring any change in current front-end logic except use of the t( ) utility method where needed.

_Notes re. client tests_
A mock of the displayTextContext was needed to fix the failing tests on Layout and AdminPopup components. 

In Layout this has been added directly in the same manner as the previously added AuthContext mock.

In AdminPopup a test utility function pattern has been used - this wrapper `/src/utils/test/test.utils.tsx` can be used when tests just need a mock of all context providers (without any specific context params) to be in the tree for the test to run. It's used in AdminPopup as an extension of the standard library render function.

This util follows the pattern laid out in React Testing Library docs: https://testing-library.com/docs/react-testing-library/setup#custom-render 

This util might want to be broken out into a separate PR for clarity.