### PR TITLE
feat: add toast context

### DIFF
--- a/client/src/components/AdminPopup/AdminPopup.test.tsx
+++ b/client/src/components/AdminPopup/AdminPopup.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import AdminPopup from './AdminPopup';
 import {
@@ -6,6 +6,7 @@ import {
   useDepartmentsAndGendersAndRolesQuery,
   useGetAllUsersQuery
 } from '../../generated/graphql-types';
+import { renderWithAllProviders as render } from '../../utils/test/test.utils';
 
 vi.mock('../../generated/graphql-types', async () => {
   const actual = await vi.importActual('../../generated/graphql-types');
@@ -14,6 +15,14 @@ vi.mock('../../generated/graphql-types', async () => {
     useDepartmentsAndGendersAndRolesQuery: vi.fn(),
     useGetAllUsersQuery: vi.fn(),
     useAddUserMutation: vi.fn()
+  };
+});
+
+vi.mock('../../contexts/toasts/ToastContext', async () => {
+  const actual = await vi.importActual('../../contexts/toasts/ToastContext');
+  return {
+    ...actual,
+    useToast: () => ({ showToast: vi.fn() })
   };
 });
 

--- a/client/src/components/AdminPopup/AdminPopup.tsx
+++ b/client/src/components/AdminPopup/AdminPopup.tsx
@@ -7,12 +7,14 @@ import {
 } from '../../generated/graphql-types';
 import { useCreateUserForm } from './useCreateUserForm';
 import { AdminPopupProps, InputError } from './AdminPopup.types';
+import { useToast } from '../../contexts/toasts/useToast';
 
 const AdminPopup = forwardRef<HTMLDialogElement, AdminPopupProps>(
   ({ close, refetchUsers }, ref) => {
     const { data: departmentsAndGendersAndRoles } =
       useDepartmentsAndGendersAndRolesQuery();
 
+    const { showToast } = useToast();
     const [loading, setLoading] = useState(false);
     const [createUser] = useAddUserMutation();
     const {
@@ -54,8 +56,8 @@ const AdminPopup = forwardRef<HTMLDialogElement, AdminPopupProps>(
           gender: ''
         });
         setInputError({});
-        // TODO: replace with a snackbar when available
         close();
+        showToast('Utilisateur créé avec succès!', 'success');
       } catch (error: unknown) {
         if (
           typeof error === 'object' &&
@@ -65,6 +67,7 @@ const AdminPopup = forwardRef<HTMLDialogElement, AdminPopupProps>(
           setInputError(error as InputError);
         } else {
           console.error('Unexpected error:', error);
+          showToast('Une erreur inattendue est survenue.', 'error');
         }
       } finally {
         setLoading(false);

--- a/client/src/contexts/toasts/ToastContext.tsx
+++ b/client/src/contexts/toasts/ToastContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useState, ReactNode } from 'react';
+import { Toast, ToastContextType } from './ToastContext.types';
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = (message: string, type: Toast['type']) => {
+    setToasts((prev) => [...prev, { message, type }]);
+
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((_, index) => index !== 0));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="toast toast-end">
+        {toasts.map((toast, index) => (
+          <div
+            key={index}
+            className={`alert text-white shadow-sm shadow-[#595959] ${
+              toast.type === 'success' ? 'alert-success' : 'alert-error'
+            }`}
+          >
+            <span>{toast.message}</span>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastContext;

--- a/client/src/contexts/toasts/ToastContext.types.ts
+++ b/client/src/contexts/toasts/ToastContext.types.ts
@@ -1,0 +1,8 @@
+export type Toast = {
+  message: string;
+  type: 'success' | 'error';
+};
+
+export type ToastContextType = {
+  showToast: (message: string, type: Toast['type']) => void;
+};

--- a/client/src/contexts/toasts/useToast.ts
+++ b/client/src/contexts/toasts/useToast.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import ToastContext from './ToastContext';
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -12,6 +12,7 @@ import Dossier from './pages/Dossier/Dossier.tsx';
 import AgentHome from './pages/AgentHome/AgentHome.tsx';
 import './index.css';
 import DossierBrowser from './pages/DossierBrowser/DossierBrowser.tsx';
+import { ToastProvider } from './contexts/toasts/ToastContext.tsx';
 
 const router = createBrowserRouter([
   {
@@ -67,7 +68,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ApolloProvider client={client}>
       <AuthProvider>
-        <RouterProvider router={router} />
+        <ToastProvider>
+          <RouterProvider router={router} />
+        </ToastProvider>
       </AuthProvider>
     </ApolloProvider>
   </StrictMode>

--- a/client/src/utils/test/test.utils.tsx
+++ b/client/src/utils/test/test.utils.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { ToastProvider } from '../../contexts/toasts/ToastContext';
+import { AuthProvider } from '../../contexts/auth/AuthContext';
+import { MockedProvider } from '@apollo/client/testing';
+
+// This is a custom render function that wraps the component to be tested in all required providers.
+// This allows tests that just need providers to be in the tree to be written more easily.
+// https://testing-library.com/docs/react-testing-library/setup#custom-render
+const AllProviders = ({ children }: { children: ReactNode }) => {
+  return (
+    <MockedProvider mocks={[]} addTypename={false}>
+      <AuthProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </AuthProvider>
+    </MockedProvider>
+  );
+};
+
+export const renderWithAllProviders = (
+  ui: React.ReactElement,
+  options?: RenderOptions
+) => render(ui, { wrapper: AllProviders, ...options });


### PR DESCRIPTION
Adding a context using [Daisy UI "Toast"](https://daisyui.com/components/toast/) component, so we can display a message (of type success or error) when an action has been done

+ Adding @teasmade utils/test/utils.test.tsx to mock our providers for test purposes

### **Usage:** 

1) Import useToast hook in your component (`import { useToast } from '[...]/contexts/toasts/useToast';`)
2) get the showToast fonction (`const { showToast } = useToast();`)
3) Call the showTast function wherever you need  (`showToast('Utilisateur créé avec succès!', 'success');`) and replace success with error for an error

Preview:

https://github.com/user-attachments/assets/2290a795-ffa7-4dbc-850c-d199303632bd

