### PR TITLE
FIX: updated protected route to fire navigation logic inside useEffect

### DIFF
--- a/client/src/components/shared_components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/shared_components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 import { useAuth } from '../../../contexts/auth/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { roleLandingPages } from '../../../pages/Login/roleLandingPages';
@@ -10,16 +10,23 @@ export default function ProtectedRoute({
   const { user } = useAuth();
   const navigate = useNavigate();
 
-  if (!user) {
-    navigate('/');
-    return null;
-  }
+  useEffect(() => {
+    if (!user) {
+      navigate('/');
+      return;
+    }
 
-  if (!allowedRoles.includes(user.role.code)) {
-    navigate(
-      roleLandingPages[user.role.code as keyof typeof roleLandingPages],
-      { replace: true }
-    );
+    if (!allowedRoles.includes(user.role.code)) {
+      navigate(
+        roleLandingPages[user.role.code as keyof typeof roleLandingPages],
+        { replace: true }
+      );
+    }
+  }, [user, allowedRoles, navigate]);
+
+  // Only render children if the user is authenticated and has the appropriate role
+  if (!user || !allowedRoles.includes(user.role.code)) {
+    return null;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
This clears React errors on calling setState during another component's render