### PR TITLE
Feature/access control

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -51,7 +51,7 @@ const router = createBrowserRouter([
       {
         path: 'dossiers',
         element: (
-          <ProtectedRoute allowedRoles={[RoleCode.Agent]}>
+          <ProtectedRoute allowedRoles={[RoleCode.Doctor]}>
             <DossierBrowser />
           </ProtectedRoute>
         )

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -34,19 +34,35 @@ const router = createBrowserRouter([
       },
       {
         path: 'planning',
-        element: <RoleBasedPlanning />
+        element: (
+          <ProtectedRoute allowedRoles={[RoleCode.Doctor, RoleCode.Secretary]}>
+            <RoleBasedPlanning />
+          </ProtectedRoute>
+        )
       },
       {
         path: 'rechercher',
-        element: <AgentHome />
+        element: (
+          <ProtectedRoute allowedRoles={[RoleCode.Agent]}>
+            <AgentHome />
+          </ProtectedRoute>
+        )
       },
       {
         path: 'dossiers',
-        element: <DossierBrowser />
+        element: (
+          <ProtectedRoute allowedRoles={[RoleCode.Agent]}>
+            <DossierBrowser />
+          </ProtectedRoute>
+        )
       },
       {
         path: 'patient/:patientId/dossier',
-        element: <Dossier />
+        element: (
+          <ProtectedRoute allowedRoles={[RoleCode.Doctor]}>
+            <Dossier />
+          </ProtectedRoute>
+        )
       },
       {
         path: 'admin',

--- a/core_api/src/modules/consultation/consultation.resolver.ts
+++ b/core_api/src/modules/consultation/consultation.resolver.ts
@@ -3,7 +3,6 @@ import { Resolver, Query, Arg, Authorized } from 'type-graphql';
 
 @Resolver(Consultation)
 export default class ConsultationResolver {
-  // TODO : rescrtict access to role === doctor
   @Authorized([RoleCode.DOCTOR])
   @Query(() => [Consultation])
   async dossier(@Arg('patientId') patientId: string) {

--- a/core_api/src/modules/consultation/consultation.resolver.ts
+++ b/core_api/src/modules/consultation/consultation.resolver.ts
@@ -1,9 +1,10 @@
-import { Consultation } from '../entities.index';
-import { Resolver, Query, Arg } from 'type-graphql';
+import { Consultation, RoleCode } from '../entities.index';
+import { Resolver, Query, Arg, Authorized } from 'type-graphql';
 
 @Resolver(Consultation)
 export default class ConsultationResolver {
   // TODO : rescrtict access to role === doctor
+  @Authorized([RoleCode.DOCTOR])
   @Query(() => [Consultation])
   async dossier(@Arg('patientId') patientId: string) {
     return await Consultation.find({
@@ -20,6 +21,7 @@ export default class ConsultationResolver {
 
   // TODO : talk amongst ourselves on how to restrict the dates ? Maybe refetch based on the calendar's view ?
   // in this case, it should also take a end date
+  @Authorized([RoleCode.DOCTOR, RoleCode.SECRETARY])
   @Query(() => [Consultation])
   async consultationsByDoctorId(@Arg('doctorId') doctorId: string) {
     return await Consultation.find({

--- a/core_api/src/modules/department/department.resolver.ts
+++ b/core_api/src/modules/department/department.resolver.ts
@@ -1,8 +1,9 @@
 import { Department, Role, RoleCode } from '../entities.index';
-import { Resolver, Query } from 'type-graphql';
+import { Resolver, Query, Authorized } from 'type-graphql';
 
 @Resolver(Department)
 export default class DepartmentResolver {
+  @Authorized([RoleCode.ADMIN, RoleCode.AGENT])
   @Query(() => [Department])
   async departments() {
     return await Department.find({
@@ -10,6 +11,7 @@ export default class DepartmentResolver {
     });
   }
 
+  @Authorized([RoleCode.SECRETARY])
   @Query(() => [Department], {
     description: 'Fetches all departments and their doctors'
   })

--- a/core_api/src/modules/department/department.test.ts
+++ b/core_api/src/modules/department/department.test.ts
@@ -1,5 +1,5 @@
 import getSchema from '../../schema';
-import { graphql, GraphQLSchema, print } from 'graphql';
+import { graphql, GraphQLSchema, print, ExecutionResult } from 'graphql';
 import gql from 'graphql-tag';
 import { RoleCode } from '../entities.index';
 import { MockUser } from '../../types/MockUserType';
@@ -33,41 +33,45 @@ describe('Department resolvers', () => {
 
   it('Can get all departments as an AGENT', async () => {
     mockUser.role.code = RoleCode.AGENT;
-    const result = (await graphql({
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_DEPARTMENT),
       contextValue
-    })) as { data: { departments: Array<unknown> } };
-    expect(result.data.departments).toEqual(expect.any(Array));
+    });
+    expect(result.data?.departments).toEqual(expect.any(Array));
+    expect(result.errors).toBeUndefined();
   });
 
   it('Can get all departments as an ADMIN', async () => {
     mockUser.role.code = RoleCode.ADMIN;
-    const result = (await graphql({
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_DEPARTMENT),
       contextValue
     })) as { data: { departments: Array<unknown> } };
-    expect(result.data.departments).toEqual(expect.any(Array));
+    expect(result.data?.departments).toEqual(expect.any(Array));
+    expect(result.errors).toBeUndefined();
   });
 
   it('Cannot get all departments as a SECRETARY', async () => {
     mockUser.role.code = RoleCode.SECRETARY;
-    const result = (await graphql({
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_DEPARTMENT),
       contextValue
-    })) as { errors: Array<unknown> };
+    });
     expect(result.errors).toEqual(expect.any(Array));
+    expect(result.data).toBeNull();
   });
 
   it('Cannot get all departments as a DOCTOR', async () => {
     mockUser.role.code = RoleCode.DOCTOR;
-    const result = (await graphql({
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_DEPARTMENT),
       contextValue
-    })) as { errors: Array<unknown> };
+    });
     expect(result.errors).toEqual(expect.any(Array));
+    expect(result.data).toBeNull();
   });
 });

--- a/core_api/src/modules/department/department.test.ts
+++ b/core_api/src/modules/department/department.test.ts
@@ -1,6 +1,8 @@
 import getSchema from '../../schema';
 import { graphql, GraphQLSchema, print } from 'graphql';
 import gql from 'graphql-tag';
+import { RoleCode } from '../entities.index';
+import { MockUser } from '../../types/MockUserType';
 
 const GET_DEPARTMENT = gql`
   query TestDepartmentQuery {
@@ -11,16 +13,61 @@ const GET_DEPARTMENT = gql`
   }
 `;
 
+const mockUser: MockUser = {
+  id: '1',
+  role: {
+    code: null // to change for each test
+  }
+};
+
+const contextValue = {
+  user: mockUser
+};
+
 describe('Department resolvers', () => {
   let schema: GraphQLSchema;
+
   beforeAll(async () => {
     schema = await getSchema();
   });
-  it('get all department', async () => {
+
+  it('Can get all departments as an AGENT', async () => {
+    mockUser.role.code = RoleCode.AGENT;
     const result = (await graphql({
       schema: schema,
-      source: print(GET_DEPARTMENT)
+      source: print(GET_DEPARTMENT),
+      contextValue
     })) as { data: { departments: Array<unknown> } };
     expect(result.data.departments).toEqual(expect.any(Array));
+  });
+
+  it('Can get all departments as an ADMIN', async () => {
+    mockUser.role.code = RoleCode.ADMIN;
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_DEPARTMENT),
+      contextValue
+    })) as { data: { departments: Array<unknown> } };
+    expect(result.data.departments).toEqual(expect.any(Array));
+  });
+
+  it('Cannot get all departments as a SECRETARY', async () => {
+    mockUser.role.code = RoleCode.SECRETARY;
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_DEPARTMENT),
+      contextValue
+    })) as { errors: Array<unknown> };
+    expect(result.errors).toEqual(expect.any(Array));
+  });
+
+  it('Cannot get all departments as a DOCTOR', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_DEPARTMENT),
+      contextValue
+    })) as { errors: Array<unknown> };
+    expect(result.errors).toEqual(expect.any(Array));
   });
 });

--- a/core_api/src/modules/gender/gender.resolver.ts
+++ b/core_api/src/modules/gender/gender.resolver.ts
@@ -1,8 +1,9 @@
-import { Gender } from '../entities.index';
-import { Resolver, Query } from 'type-graphql';
+import { Gender, RoleCode } from '../entities.index';
+import { Resolver, Query, Authorized } from 'type-graphql';
 
 @Resolver(Gender)
 export default class GenderResolver {
+  @Authorized([RoleCode.ADMIN])
   @Query(() => [Gender])
   async genders() {
     return await Gender.find({

--- a/core_api/src/modules/patient/patient.resolver.ts
+++ b/core_api/src/modules/patient/patient.resolver.ts
@@ -1,10 +1,10 @@
-import { Resolver, Query, Arg } from 'type-graphql';
+import { Resolver, Query, Arg, Authorized } from 'type-graphql';
 import { ILike } from 'typeorm';
-import { Patient } from '../entities.index';
+import { Patient, RoleCode } from '../entities.index';
 
 @Resolver(Patient)
 export default class PatientResolver {
-  // TODO : rescrtict access to role === doctor | secretary
+  @Authorized([RoleCode.DOCTOR, RoleCode.SECRETARY])
   @Query(() => Patient)
   async patient(@Arg('patientId') patientId: string) {
     return await Patient.findOne({
@@ -15,9 +15,9 @@ export default class PatientResolver {
     });
   }
 
-  // TODO : rescrtict access to role === doctor | secretary
   // needed to browse patients by their firstname,lastname or SSN, case insensitive
   @Query(() => [Patient])
+  @Authorized([RoleCode.DOCTOR, RoleCode.SECRETARY])
   async patients(@Arg('search') search: string) {
     search = search.trim();
     if (!search) return [];

--- a/core_api/src/modules/patient/patient.test.ts
+++ b/core_api/src/modules/patient/patient.test.ts
@@ -1,5 +1,5 @@
 import getSchema from '../../schema';
-import { graphql, GraphQLSchema, print } from 'graphql';
+import { graphql, GraphQLSchema, print, ExecutionResult } from 'graphql';
 import gql from 'graphql-tag';
 import { RoleCode } from '../entities.index';
 import { MockUser } from '../../types/MockUserType';
@@ -41,7 +41,8 @@ describe('Patient resolver', () => {
       firstname: 'Penelope',
       lastname: 'Patient'
     };
-    const result = (await graphql({
+
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
@@ -52,10 +53,16 @@ describe('Patient resolver', () => {
       };
     };
 
-    expect(result.data.patients).toContainEqual(
+    expect(result.data?.patients).toContainEqual(
       expect.objectContaining(expectedResult)
     );
-    result.data.patients.forEach((patient) => {
+    (
+      result.data?.patients as Array<{
+        id: string;
+        firstname: string;
+        lastname: string;
+      }>
+    ).forEach((patient) => {
       expect(patient).toHaveProperty('id');
       expect(typeof patient.id).toBe('string');
     });
@@ -68,7 +75,8 @@ describe('Patient resolver', () => {
       firstname: 'Penelope',
       lastname: 'Patient'
     };
-    const result = (await graphql({
+
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
@@ -79,10 +87,16 @@ describe('Patient resolver', () => {
       };
     };
 
-    expect(result.data.patients).toContainEqual(
+    expect(result.data?.patients).toContainEqual(
       expect.objectContaining(expectedResult)
     );
-    result.data.patients.forEach((patient) => {
+    (
+      result.data?.patients as Array<{
+        id: string;
+        firstname: string;
+        lastname: string;
+      }>
+    ).forEach((patient) => {
       expect(patient).toHaveProperty('id');
       expect(typeof patient.id).toBe('string');
     });
@@ -91,27 +105,31 @@ describe('Patient resolver', () => {
   it('Cannot search for patients by name as an AGENT', async () => {
     mockUser.role.code = RoleCode.AGENT;
     const searchValue = 'pen';
-    const result = (await graphql({
+
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
       variableValues: { search: searchValue }
-    })) as { errors: Array<unknown> };
+    });
 
     expect(result.errors).toEqual(expect.any(Array));
+    expect(result.data).toBeNull();
   });
 
   it('Cannot search for patients by name as an ADMIN', async () => {
     mockUser.role.code = RoleCode.ADMIN;
     const searchValue = 'pen';
-    const result = (await graphql({
+
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
       variableValues: { search: searchValue }
-    })) as { errors: Array<unknown> };
+    });
 
     expect(result.errors).toEqual(expect.any(Array));
+    expect(result.data).toBeNull();
   });
 
   // Search functionality
@@ -122,7 +140,8 @@ describe('Patient resolver', () => {
       firstname: 'Penelope',
       lastname: 'Patient'
     };
-    const result = (await graphql({
+
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
@@ -133,10 +152,16 @@ describe('Patient resolver', () => {
       };
     };
 
-    expect(result.data.patients).toContainEqual(
+    expect(result.data?.patients).toContainEqual(
       expect.objectContaining(expectedResult)
     );
-    result.data.patients.forEach((patient) => {
+    (
+      result.data?.patients as Array<{
+        id: string;
+        firstname: string;
+        lastname: string;
+      }>
+    ).forEach((patient) => {
       expect(patient).toHaveProperty('id');
       expect(typeof patient.id).toBe('string');
     });
@@ -146,41 +171,39 @@ describe('Patient resolver', () => {
   it('returns an empty array if no patient was found', async () => {
     mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = 'noPatientMatchesThisString';
-    const result = (await graphql({
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
       variableValues: { search: searchValue }
-    })) as { data: { patients: Array<unknown> } };
+    });
 
-    expect(result.data.patients.length).toEqual(0);
+    expect(result.data?.patients).toEqual([]);
   });
 
   it('resists basic SQLi', async () => {
     mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = "' OR 1=1 --";
-    const result = (await graphql({
+    const result: ExecutionResult = await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
       variableValues: { search: searchValue }
-    })) as { data: { patients: Array<unknown> } };
+    });
 
-    expect(result.data.patients.length).toEqual(0);
+    expect(result.data?.patients).toEqual([]);
   });
 
   it('can handle empty searches', async () => {
     mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = '';
-    const result = (await graphql({
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
       contextValue,
       variableValues: { search: searchValue }
     })) as { data: { patients: Array<unknown> } };
 
-    console.info(result.data.patients);
-
-    expect(result.data.patients.length).toEqual(0);
+    expect(result.data?.patients).toEqual([]);
   });
 });

--- a/core_api/src/modules/patient/patient.test.ts
+++ b/core_api/src/modules/patient/patient.test.ts
@@ -1,6 +1,8 @@
 import getSchema from '../../schema';
 import { graphql, GraphQLSchema, print } from 'graphql';
 import gql from 'graphql-tag';
+import { RoleCode } from '../entities.index';
+import { MockUser } from '../../types/MockUserType';
 
 export const GET_PATIENTS_BY_NAME = gql`
   query GetPatientsByName($search: String!) {
@@ -12,13 +14,28 @@ export const GET_PATIENTS_BY_NAME = gql`
   }
 `;
 
+const mockUser: MockUser = {
+  id: '1',
+  role: {
+    code: null // to change for each test
+  }
+};
+
+const contextValue = {
+  user: mockUser
+};
+
 describe('Patient resolver', () => {
   let schema: GraphQLSchema;
+
   beforeAll(async () => {
     schema = await getSchema();
   });
+
   // Intended functionnality
-  it('can search for patients by name', async () => {
+  // Role access checks
+  it('Can search for patients by name as a DOCTOR', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = 'pen';
     const expectedResult = {
       firstname: 'Penelope',
@@ -27,6 +44,7 @@ describe('Patient resolver', () => {
     const result = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
       variableValues: { search: searchValue }
     })) as {
       data: {
@@ -43,7 +61,62 @@ describe('Patient resolver', () => {
     });
   });
 
+  it('Can search for patients by name as a SECRETARY', async () => {
+    mockUser.role.code = RoleCode.SECRETARY;
+    const searchValue = 'pen';
+    const expectedResult = {
+      firstname: 'Penelope',
+      lastname: 'Patient'
+    };
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
+      variableValues: { search: searchValue }
+    })) as {
+      data: {
+        patients: Array<{ id: string; firstname: string; lastname: string }>;
+      };
+    };
+
+    expect(result.data.patients).toContainEqual(
+      expect.objectContaining(expectedResult)
+    );
+    result.data.patients.forEach((patient) => {
+      expect(patient).toHaveProperty('id');
+      expect(typeof patient.id).toBe('string');
+    });
+  });
+
+  it('Cannot search for patients by name as an AGENT', async () => {
+    mockUser.role.code = RoleCode.AGENT;
+    const searchValue = 'pen';
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
+      variableValues: { search: searchValue }
+    })) as { errors: Array<unknown> };
+
+    expect(result.errors).toEqual(expect.any(Array));
+  });
+
+  it('Cannot search for patients by name as an ADMIN', async () => {
+    mockUser.role.code = RoleCode.ADMIN;
+    const searchValue = 'pen';
+    const result = (await graphql({
+      schema: schema,
+      source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
+      variableValues: { search: searchValue }
+    })) as { errors: Array<unknown> };
+
+    expect(result.errors).toEqual(expect.any(Array));
+  });
+
+  // Search functionality
   it('results aren t affected by case ', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = 'PeNel';
     const expectedResult = {
       firstname: 'Penelope',
@@ -52,6 +125,7 @@ describe('Patient resolver', () => {
     const result = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
       variableValues: { search: searchValue }
     })) as {
       data: {
@@ -70,10 +144,12 @@ describe('Patient resolver', () => {
 
   // Edge cases
   it('returns an empty array if no patient was found', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = 'noPatientMatchesThisString';
     const result = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
       variableValues: { search: searchValue }
     })) as { data: { patients: Array<unknown> } };
 
@@ -81,10 +157,12 @@ describe('Patient resolver', () => {
   });
 
   it('resists basic SQLi', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = "' OR 1=1 --";
     const result = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
       variableValues: { search: searchValue }
     })) as { data: { patients: Array<unknown> } };
 
@@ -92,10 +170,12 @@ describe('Patient resolver', () => {
   });
 
   it('can handle empty searches', async () => {
+    mockUser.role.code = RoleCode.DOCTOR;
     const searchValue = '';
     const result = (await graphql({
       schema: schema,
       source: print(GET_PATIENTS_BY_NAME),
+      contextValue,
       variableValues: { search: searchValue }
     })) as { data: { patients: Array<unknown> } };
 

--- a/core_api/src/modules/role/role.resolver.ts
+++ b/core_api/src/modules/role/role.resolver.ts
@@ -1,8 +1,9 @@
-import { Role } from '../entities.index';
-import { Resolver, Query } from 'type-graphql';
+import { Role, RoleCode } from '../entities.index';
+import { Resolver, Query, Authorized } from 'type-graphql';
 
 @Resolver(Role)
 export default class RoleResolver {
+  @Authorized([RoleCode.ADMIN])
   @Query(() => [Role])
   async roles() {
     return await Role.find();

--- a/core_api/src/modules/role/role.test.ts
+++ b/core_api/src/modules/role/role.test.ts
@@ -1,6 +1,8 @@
 import getSchema from '../../schema';
 import { graphql, GraphQLSchema, print } from 'graphql';
 import gql from 'graphql-tag';
+import { RoleCode } from '../entities.index';
+import { MockUser } from '../../types/MockUserType';
 
 const GET_ROLES = gql`
   query TestRoleQuery {
@@ -12,15 +14,29 @@ const GET_ROLES = gql`
   }
 `;
 
+const mockUser: MockUser = {
+  id: '1',
+  role: {
+    code: null // to change for each test
+  }
+};
+
+const contextValue = {
+  user: mockUser
+};
+
 describe('Repo resolvers', () => {
   let schema: GraphQLSchema;
   beforeAll(async () => {
     schema = await getSchema();
   });
-  it('get all repos', async () => {
+
+  it('Can get all roles as an ADMIN', async () => {
+    mockUser.role.code = RoleCode.ADMIN;
     const result = (await graphql({
       schema: schema,
-      source: print(GET_ROLES)
+      source: print(GET_ROLES),
+      contextValue
     })) as { data: { roles: Array<unknown> } };
     expect(result.data.roles).toEqual(expect.any(Array));
   });

--- a/core_api/src/modules/role/role.test.ts
+++ b/core_api/src/modules/role/role.test.ts
@@ -1,5 +1,5 @@
 import getSchema from '../../schema';
-import { graphql, GraphQLSchema, print } from 'graphql';
+import { graphql, GraphQLSchema, print, ExecutionResult } from 'graphql';
 import gql from 'graphql-tag';
 import { RoleCode } from '../entities.index';
 import { MockUser } from '../../types/MockUserType';
@@ -33,11 +33,11 @@ describe('Repo resolvers', () => {
 
   it('Can get all roles as an ADMIN', async () => {
     mockUser.role.code = RoleCode.ADMIN;
-    const result = (await graphql({
+    const result: ExecutionResult = (await graphql({
       schema: schema,
       source: print(GET_ROLES),
       contextValue
     })) as { data: { roles: Array<unknown> } };
-    expect(result.data.roles).toEqual(expect.any(Array));
+    expect(result.data?.roles).toEqual(expect.any(Array));
   });
 });

--- a/core_api/src/modules/user/user.resolver.ts
+++ b/core_api/src/modules/user/user.resolver.ts
@@ -30,6 +30,7 @@ dotenv.config();
 
 @Resolver(User)
 export default class UserResolver {
+  @Authorized([RoleCode.AGENT])
   @Query(() => [User], {
     description: 'Fetches all users with the role of doctor'
   })
@@ -49,6 +50,7 @@ export default class UserResolver {
     return doctors;
   }
 
+  @Authorized([RoleCode.AGENT])
   @Query(() => [Department], {
     description: 'Fetches departments by label and their doctors'
   })
@@ -77,6 +79,7 @@ export default class UserResolver {
     return departments;
   }
 
+  @Authorized([RoleCode.ADMIN])
   @Mutation(() => User)
   async addUser(
     @Arg('firstname') firstname: string,
@@ -158,6 +161,7 @@ export default class UserResolver {
   }
 
   @Query(() => [User])
+  @Authorized([RoleCode.ADMIN])
   async users() {
     return await User.find({
       // Explicitly load the "role" relationship

--- a/core_api/src/types/MockUserType.ts
+++ b/core_api/src/types/MockUserType.ts
@@ -1,0 +1,8 @@
+import { RoleCode } from '../modules/entities.index';
+
+export type MockUser = {
+  id: string;
+  role: {
+    code: RoleCode | null;
+  };
+};


### PR DESCRIPTION
- Adds role based protection to client page routes
- Adds role based protection to coreapi resolvers
- Adapts backend tests with mocked context and mock user whose role can be changed
- Adds backend tests for positive and negative cases of access-control by role (e.g. CAN get patients by name as DOCTOR, CANNOT get patients by name as AGENT)
- Adapts backend tests to use the native ExecutionResult type from Graphql, adapts negative result tests to handle the edge case that, as per the GQL spec ( https://graphql.org/learn/response/ ), a "partial" response can contain both .errors and .data properties.