### PR TITLE
Feature/full seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Env
+include .env
+export
+
 # Target: Build dev environnement
 build:
 	docker compose -f docker-compose.dev.yml build
@@ -22,3 +26,9 @@ seed-dev:
 
 codegen:
 	docker compose -f docker-compose.dev.yml run client npm run codegen
+
+seed-full:
+	docker compose -f docker-compose.dev.yml run --rm \
+	-e PGPASSWORD=${POSTGRES_PASSWORD} \
+	-v ./postgres/seed_scripts/full_seed.sql:/seed.sql \
+	${DB_HOST} psql -U postgres -d postgres -h ${DB_HOST} -f /seed.sql

--- a/client/src/components/AdminPopupDoctorHour/AdminPopupDoctorHour.tsx
+++ b/client/src/components/AdminPopupDoctorHour/AdminPopupDoctorHour.tsx
@@ -187,7 +187,8 @@ export default function AdminPopupDoctorHour({
               </label>
               {weekdays.map((day, index) => {
                 const workingHour = workingHours.find(
-                  (wh) => wh.weekday === index
+                  // weekday needs to be offset because SQL defines sun - sat as 0 - 6
+                  (wh) => wh.weekday === index + 1
                 );
 
                 return (

--- a/core_api/src/modules/department/department.entity.ts
+++ b/core_api/src/modules/department/department.entity.ts
@@ -20,6 +20,6 @@ export class Department extends BaseEntity {
   label: string;
 
   @Field(() => [User])
-  @OneToMany(() => User, (user) => user.role)
+  @OneToMany(() => User, (user) => user.department)
   users: User[];
 }

--- a/core_api/src/modules/patient/patient.entity.ts
+++ b/core_api/src/modules/patient/patient.entity.ts
@@ -32,7 +32,7 @@ export class Patient extends BaseEntity {
   email: string;
 
   @Field(() => String)
-  @Column({ nullable: false, unique: true, type: 'varchar', length: 15 })
+  @Column({ nullable: false, unique: true, type: 'varchar', length: 50 })
   ssn: string;
 
   @Field(() => String)

--- a/postgres/seed_data/import.sql
+++ b/postgres/seed_data/import.sql
@@ -27,14 +27,46 @@ CREATE TABLE raw_data (
   code_postal_patient TEXT,
   ville_patient TEXT,
   id_user INT,
-  id_patient INT,
-  id_consultation INT,
+  id_patient UUID,
+  id_consultation UUID,
   id_attach_1 INT,
-  id_attach_2 INT
+  id_attach_2 INT,
+  id_doctor UUID
 );
 
-
-COPY raw_data
+COPY raw_data (
+  consultation_description,
+  consultation_motif,
+  attachment_file_1,
+  attachment_description_1,
+  consultation_date,
+  consultation_duration,
+  consultation_start_time,
+  fullname_medecin,
+  prenom_medecin,
+  nom_medecin,
+  email_medecin,
+  genre_medecin,
+  service_medecin,
+  workdays_medecin,
+  heure_debut_medecin,
+  heure_fin_medecin,
+  fullname_patient,
+  prenom_patient,
+  nom_patient,
+  sex_patient,
+  ssn_patient,
+  email_patient,
+  attachment_file_2,
+  attachment_description_2,
+  date_naissance_patient,
+  code_postal_patient,
+  ville_patient,
+  id_user,
+  id_patient,
+  id_consultation,
+  id_attach_1,
+  id_attach_2
+)
 FROM
-'/docker-entrypoint-initdb.d/med_data_v3.csv' 
-WITH (FORMAT csv, HEADER);
+  '/docker-entrypoint-initdb.d/med_data_v3.csv' WITH (FORMAT csv, HEADER);

--- a/postgres/seed_scripts/full_seed.sql
+++ b/postgres/seed_scripts/full_seed.sql
@@ -329,7 +329,6 @@ WITH new_consultations AS (
     raw.id_doctor,
     raw.id_patient,
     (
-      -- Pull the first user who has role code 'secretary'
       SELECT
         u.id
       FROM
@@ -338,7 +337,7 @@ WITH new_consultations AS (
       WHERE
         r.code = 'secretary'
       ORDER BY
-        u.id -- or some other criterion
+        u.id
       LIMIT
         1
     ) AS authorId,
@@ -348,15 +347,14 @@ WITH new_consultations AS (
       FROM
         consultation_subject
       WHERE
-        label = raw.consultation_motif -- map motif -> subjectId
+        label = raw.consultation_motif
     )
   FROM
     raw_data raw
   WHERE
     raw.id_doctor IS NOT NULL
     AND raw.id_patient IS NOT NULL
-    AND raw.consultation_description IS NOT NULL -- etc. (additional checks if needed)
-    RETURNING id,
+    AND raw.consultation_description IS NOT NULL RETURNING id,
     description,
     "consultationDate",
     "startTime",
@@ -405,7 +403,6 @@ INSERT INTO
 SELECT
   r.id_consultation,
   (
-    -- Grab the first "secretary" user
     SELECT
       u.id
     FROM
@@ -427,7 +424,7 @@ FROM
     VALUES
       (r.attachment_file_1, r.attachment_description_1),
       (r.attachment_file_2, r.attachment_description_2)
-  ) AS x(FILE, note) ON TRUE -- Only insert rows if the file name is not null/empty:
+  ) AS x(FILE, note) ON TRUE
 WHERE
   x.file IS NOT NULL
   AND x.file <> ''

--- a/postgres/seed_scripts/full_seed.sql
+++ b/postgres/seed_scripts/full_seed.sql
@@ -1,0 +1,436 @@
+BEGIN;
+
+TRUNCATE consultation_subject,
+role,
+gender,
+department,
+working_hours,
+attachment,
+consultation,
+patient,
+"user" restart identity CASCADE;
+
+-- Seed roles
+INSERT INTO
+  "role" (code, label)
+VALUES
+  ('admin', 'administrateur'),
+  ('doctor', 'docteur'),
+  ('agent', 'agent'),
+  ('secretary', 'secrétaire');
+
+-- Seed genders
+INSERT INTO
+  "gender" (label)
+VALUES
+  ('Male'),
+  ('Female'),
+  ('NA');
+
+-- Seed departments
+INSERT INTO
+  department (label)
+SELECT
+  DISTINCT service_medecin
+FROM
+  raw_data rd;
+
+-- Seed consultation subjects
+INSERT INTO
+  consultation_subject (label)
+SELECT
+  DISTINCT consultation_motif
+FROM
+  raw_data rd;
+
+-- Seed users 1 - Doctors
+-- 1) Match and insert doctors, return their IDs + emails
+WITH new_doctors AS (
+  INSERT INTO
+    "user" (
+      firstname,
+      lastname,
+      email,
+      "roleId",
+      "departmentId",
+      "genderId",
+      PASSWORD
+    )
+  SELECT
+    DISTINCT prenom_medecin,
+    nom_medecin,
+    email_medecin,
+    (
+      SELECT
+        id
+      FROM
+        role
+      WHERE
+        role.code = 'doctor'
+    ) AS roleId,
+    (
+      SELECT
+        id
+      FROM
+        department
+      WHERE
+        department.label = raw.service_medecin
+    ) AS departmentId,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        gender.label = CASE
+          WHEN raw.genre_medecin = 'Homme' THEN 'Male'
+          ELSE 'Female'
+        END
+    ) AS genderId,
+    '$argon2id$v=19$m=65536,t=3,p=4$HiwWuHvgEopNOIIEA3UIRw$BhD+ZPAnOnJ64tXcYNIv1NwjzDpk+kewifoW9FUO5Sk'
+  FROM
+    raw_data raw returning id,
+    email
+) -- 2) Update raw_data with the new user (doctor) IDs
+UPDATE
+  raw_data r
+SET
+  id_doctor = nd.id
+FROM
+  new_doctors nd
+WHERE
+  nd.email = r.email_medecin;
+
+-- Seed users 2 - fake Doctor, Agent, Secretary, Admin
+INSERT INTO
+  "user" (
+    firstname,
+    lastname,
+    email,
+    "roleId",
+    "departmentId",
+    "genderId",
+    PASSWORD
+  )
+VALUES
+  (
+    'Cyril',
+    'Convergence',
+    'fakedoctor@fake.com',
+    (
+      SELECT
+        id
+      FROM
+        role
+      WHERE
+        role.code = 'doctor'
+    ),
+    1,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        gender.label = 'Male'
+    ),
+    '$argon2id$v=19$m=65536,t=3,p=4$HiwWuHvgEopNOIIEA3UIRw$BhD+ZPAnOnJ64tXcYNIv1NwjzDpk+kewifoW9FUO5Sk'
+  ),
+  (
+    'Alice',
+    'Admin',
+    'fakeadmin@fake.com',
+    (
+      SELECT
+        id
+      FROM
+        role
+      WHERE
+        role.code = 'admin'
+    ),
+    NULL,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        gender.label = 'Female'
+    ),
+    '$argon2id$v=19$m=65536,t=3,p=4$HiwWuHvgEopNOIIEA3UIRw$BhD+ZPAnOnJ64tXcYNIv1NwjzDpk+kewifoW9FUO5Sk'
+  ),
+  (
+    'Anna',
+    'Agent',
+    'fakeagent@fake.com',
+    (
+      SELECT
+        id
+      FROM
+        role
+      WHERE
+        role.code = 'agent'
+    ),
+    NULL,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        gender.label = 'Female'
+    ),
+    '$argon2id$v=19$m=65536,t=3,p=4$HiwWuHvgEopNOIIEA3UIRw$BhD+ZPAnOnJ64tXcYNIv1NwjzDpk+kewifoW9FUO5Sk'
+  ),
+  (
+    'Samuel',
+    'Secretary',
+    'fakesecretary@fake.com',
+    (
+      SELECT
+        id
+      FROM
+        role
+      WHERE
+        role.code = 'secretary'
+    ),
+    NULL,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        gender.label = 'Male'
+    ),
+    '$argon2id$v=19$m=65536,t=3,p=4$HiwWuHvgEopNOIIEA3UIRw$BhD+ZPAnOnJ64tXcYNIv1NwjzDpk+kewifoW9FUO5Sk'
+  );
+
+INSERT INTO
+  "working_hours" ("doctorId", "weekday", "startTime", "endTime")
+SELECT
+  sub.id_doctor :: uuid,
+  CASE
+    LOWER(TRIM(day_txt))
+    WHEN 'dimanche' THEN 0
+    WHEN 'lundi' THEN 1
+    WHEN 'mardi' THEN 2
+    WHEN 'mercredi' THEN 3
+    WHEN 'jeudi' THEN 4
+    WHEN 'vendredi' THEN 5
+    WHEN 'samedi' THEN 6
+  END AS weekday,
+  sub.heure_debut_medecin AS startTime,
+  sub.heure_fin_medecin AS endTime
+FROM
+  (
+    -- Subquery: distinct rows (so each doctor is only taken once)
+    SELECT
+      DISTINCT id_doctor,
+      workdays_medecin,
+      heure_debut_medecin,
+      heure_fin_medecin
+    FROM
+      raw_data
+    WHERE
+      id_doctor IS NOT NULL
+      AND workdays_medecin IS NOT NULL
+      AND workdays_medecin <> ''
+  ) AS sub -- Split comma-separated day strings
+  -- JOIN LATERAL return one row per item for the set defined on the right side of the join
+  -- The comma separated string is split via an array to return multiple weekdays
+  -- So for each distinct doctor row on the left, we get as many weekdays as existed in the string
+  -- We join on true because we want to include all of these
+  -- We call this day_txt for use in the previously defined case - when mapping to day numbers
+  JOIN LATERAL unnest(string_to_array(sub.workdays_medecin, ',')) day_txt ON TRUE;
+
+-- Seed Patients
+-- 1) Insert into patients, returning (id, email)
+WITH new_patients AS (
+  INSERT INTO
+    "patient" (
+      firstname,
+      lastname,
+      email,
+      ssn,
+      town,
+      postcode,
+      "dateOfBirth",
+      "genderId"
+    )
+  SELECT
+    DISTINCT raw.prenom_patient,
+    raw.nom_patient,
+    raw.email_patient,
+    raw.ssn_patient,
+    raw.ville_patient,
+    raw.code_postal_patient,
+    raw.date_naissance_patient,
+    (
+      SELECT
+        id
+      FROM
+        gender
+      WHERE
+        label = CASE
+          WHEN raw.sex_patient = 'M' THEN 'Male'
+          ELSE 'Female'
+        END
+    )
+  FROM
+    raw_data raw
+  WHERE
+    raw.email_patient IS NOT NULL RETURNING id,
+    email
+) -- 2) Update raw_data with the new patient IDs
+UPDATE
+  raw_data r
+SET
+  id_patient = np.id
+FROM
+  new_patients np
+WHERE
+  np.email = r.email_patient;
+
+-- Seed Consultations
+-- 1) Insert new consultations from raw_data
+WITH new_consultations AS (
+  INSERT INTO
+    "consultation" (
+      "description",
+      "consultationDate",
+      "startTime",
+      "durationMinutes",
+      "doctorId",
+      "patientId",
+      "authorId",
+      "subjectId"
+    )
+  SELECT
+    DISTINCT raw.consultation_description,
+    CASE
+      WHEN raw.consultation_date = '2024-02-29' THEN '2025-02-28' :: date
+      ELSE make_date(
+        2025,
+        EXTRACT(
+          MONTH
+          FROM
+            raw.consultation_date
+        ) :: int,
+        EXTRACT(
+          DAY
+          FROM
+            raw.consultation_date
+        ) :: int
+      )
+    END AS consultationDate,
+    raw.consultation_start_time,
+    raw.consultation_duration,
+    raw.id_doctor,
+    raw.id_patient,
+    (
+      -- Pull the first user who has role code 'secretary'
+      SELECT
+        u.id
+      FROM
+        "user" u
+        JOIN role r ON r.id = u."roleId"
+      WHERE
+        r.code = 'secretary'
+      ORDER BY
+        u.id -- or some other criterion
+      LIMIT
+        1
+    ) AS authorId,
+    (
+      SELECT
+        id
+      FROM
+        consultation_subject
+      WHERE
+        label = raw.consultation_motif -- map motif -> subjectId
+    )
+  FROM
+    raw_data raw
+  WHERE
+    raw.id_doctor IS NOT NULL
+    AND raw.id_patient IS NOT NULL
+    AND raw.consultation_description IS NOT NULL -- etc. (additional checks if needed)
+    RETURNING id,
+    description,
+    "consultationDate",
+    "startTime",
+    "durationMinutes",
+    "doctorId",
+    "patientId"
+) -- 2) Update raw_data so it knows about the new consultation IDs
+UPDATE
+  raw_data r
+SET
+  id_consultation = nc.id
+FROM
+  new_consultations nc
+WHERE
+  r.consultation_description = nc.description
+  AND CASE
+    WHEN r.consultation_date = '2024-02-29' THEN '2025-02-28' :: date
+    ELSE make_date(
+      2025,
+      EXTRACT(
+        MONTH
+        FROM
+          r.consultation_date
+      ) :: int,
+      EXTRACT(
+        DAY
+        FROM
+          r.consultation_date
+      ) :: int
+    )
+  END = nc."consultationDate"
+  AND r.consultation_start_time = nc."startTime"
+  AND r.consultation_duration = nc."durationMinutes"
+  AND r.id_doctor = nc."doctorId"
+  AND r.id_patient = nc."patientId";
+
+-- Seed Attachments
+INSERT INTO
+  "attachment" (
+    "consultationId",
+    "authorId",
+    "fileDisplayName",
+    "note",
+    "filePath"
+  )
+SELECT
+  r.id_consultation,
+  (
+    -- Grab the first "secretary" user
+    SELECT
+      u.id
+    FROM
+      "user" u
+      JOIN role rr ON rr.id = u."roleId"
+    WHERE
+      rr.code = 'secretary'
+    ORDER BY
+      u.id
+    LIMIT
+      1
+  ) AS authorId,
+  x.file AS fileDisplayName,
+  x.note AS note,
+  '/upload/attachments/' || x.file AS filePath
+FROM
+  raw_data r
+  JOIN LATERAL (
+    VALUES
+      (r.attachment_file_1, r.attachment_description_1),
+      (r.attachment_file_2, r.attachment_description_2)
+  ) AS x(FILE, note) ON TRUE -- Only insert rows if the file name is not null/empty:
+WHERE
+  x.file IS NOT NULL
+  AND x.file <> ''
+  AND r.id_consultation IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
- Adds a full seed script to map client data to our database structure and populate tables.
- Corrects a couple of related minor errors in entity structure and mapping of weekday numbers in the client.

(To run this script, you'll first need to delete current dev postgres containers and volumes and then relaunch; the previous import script, which is needed to set things up before this one, has a slightly changed structure, and will only run when postgres does the first initial setup of the database in the container.)

The full seed script can currently be run, with dev containers up, with the command `make seed-full`. This launches a temporary container through which the full seed script is executed with psql.