### PR TITLE
HOTFIX : added pwd into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ codegen:
 seed-full:
 	docker compose -f docker-compose.dev.yml run --rm \
 	-e PGPASSWORD=${POSTGRES_PASSWORD} \
-	-v ./postgres/seed_scripts/full_seed.sql:/seed.sql \
+	-v $(shell pwd)/postgres/seed_scripts/full_seed.sql:/seed.sql \
 	${DB_HOST} psql -U postgres -d postgres -h ${DB_HOST} -f /seed.sql


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/10c8dde9-a3b4-425b-93e7-bca6e80d5139)
pwd was needed on win 11 and linux arch but not on win 10 apparently ? 