### PR TITLE
FIX/client/planning-selects

### DIFF
--- a/client/src/components/secretary_components/DoctorSelector/DoctorSelector.tsx
+++ b/client/src/components/secretary_components/DoctorSelector/DoctorSelector.tsx
@@ -57,15 +57,18 @@ export default function DoctorSelector({
             </div>
             <select
               className="select select-bordered"
-              defaultValue={departments[0].label}
+              defaultValue=""
               onChange={(e) => {
                 const newDepartment = departments.find(
                   (d) => d.label === e.target.value
                 );
                 setDepartment(newDepartment || defaultDept);
-                setDoctor(newDepartment?.users[0] || defaultDoctor);
+                setDoctor(defaultDoctor);
               }}
             >
+              <option value="" disabled>
+                Sélectionnez un service
+              </option>
               {departments.map((d) => (
                 <option key={d.id}>{d.label}</option>
               ))}
@@ -82,11 +85,14 @@ export default function DoctorSelector({
                 const newDoctor = doctors.find(
                   (d) => `${d.firstname} ${d.lastname}` === e.target.value
                 );
-                if (newDoctor?.id != doctor.id)
-                  setDoctor(newDoctor || defaultDoctor);
+                setDoctor(newDoctor || defaultDoctor);
               }}
-              defaultValue={`${doctor.firstname} ${doctor.lastname}`}
+              value={doctor.id ? `${doctor.firstname} ${doctor.lastname}` : ''}
+              disabled={department.id === 0}
             >
+              <option value="" disabled>
+                Sélectionnez un médecin
+              </option>
               {doctors.length ? (
                 doctors.map((d) => (
                   <option key={d.id}>


### PR DESCRIPTION
Make secretary planning doctor / department select behaviour cleaner / more intuitive.

Previously, loading the secretary planning page would result in the first department being auto selected and an "unknown doctor" message appearing in the doctor select; in addition selecting a department would always auto-select the first doctor from that department.

This fix adjusts makes behaviour more predictable and only launch queries when a doctor is explicitly selected.

Now both selects default to a static "Select a service / doctor" message; in addition changing the department selector will reset the doctor selector back to the "Select a doctor" message.

![image](https://github.com/user-attachments/assets/66be4bc1-347b-4361-a5c6-c280bb24cefc)
